### PR TITLE
feat: search add config indexes key prefix

### DIFF
--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -6,7 +6,8 @@ const CONFIG = {
   noData: 'No Results!',
   paths: 'auto',
   depth: 2,
-  maxAge: 86400000 // 1 day
+  maxAge: 86400000, // 1 day
+  indexPrefix: ''
 }
 
 const install = function (hook, vm) {
@@ -21,6 +22,7 @@ const install = function (hook, vm) {
     CONFIG.placeholder = opts.placeholder || CONFIG.placeholder
     CONFIG.noData = opts.noData || CONFIG.noData
     CONFIG.depth = opts.depth || CONFIG.depth
+    CONFIG.indexPrefix = opts.indexPrefix || CONFIG.indexPrefix
   }
 
   const isAuto = CONFIG.paths === 'auto'

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -34,9 +34,9 @@ function getAllPaths(router) {
   return paths
 }
 
-function saveData(maxAge) {
-  localStorage.setItem('docsify.search.expires', Date.now() + maxAge)
-  localStorage.setItem('docsify.search.index', JSON.stringify(INDEXS))
+function saveData(indexPrefix, maxAge) {
+  localStorage.setItem(indexPrefix + 'docsify.search.expires', Date.now() + maxAge)
+  localStorage.setItem(indexPrefix + 'docsify.search.index', JSON.stringify(INDEXS))
 }
 
 export function genIndex(path, content = '', router, depth) {
@@ -152,9 +152,9 @@ export function init(config, vm) {
   helper = Docsify
 
   const isAuto = config.paths === 'auto'
-  const isExpired = localStorage.getItem('docsify.search.expires') < Date.now()
+  const isExpired = localStorage.getItem(config.indexPrefix + 'docsify.search.expires') < Date.now()
 
-  INDEXS = JSON.parse(localStorage.getItem('docsify.search.index'))
+  INDEXS = JSON.parse(localStorage.getItem(config.indexPrefix + 'docsify.search.index'))
 
   if (isExpired) {
     INDEXS = {}
@@ -175,7 +175,7 @@ export function init(config, vm) {
       .get(vm.router.getFile(path), false, vm.config.requestHeaders)
       .then(result => {
         INDEXS[path] = genIndex(path, result, vm.router, config.depth)
-        len === ++count && saveData(config.maxAge)
+        len === ++count && saveData(config.indexPrefix, config.maxAge)
       })
   })
 }


### PR DESCRIPTION
一个网站有多个 docsify (实例）文档时，文档索引支持独立设置 localStorage 缓存 key，以避免搜索结果混乱
