### PR TITLE
Ability to set a custom page title via _sidebar.md

### DIFF
--- a/src/core/event/sidebar.js
+++ b/src/core/event/sidebar.js
@@ -78,7 +78,11 @@ export function getAndActive(router, el, isParent, autoTitle) {
   })
 
   if (autoTitle) {
-    dom.$.title = target ? `${target.innerText} - ${title}` : title
+    if(target && target.title){
+      dom.$.title = target.title
+    }else{
+      dom.$.title = target ? `${target.innerText} - ${title}` : title
+    }
   }
 
   return target


### PR DESCRIPTION
This PR introduces a new way to customize page's 'title' HTML tag. 

We can provide sidebar links with titles, e.g.
`* [Getting Started](ios/getting-started.md "Getting started with iOS SDK toolkit")`

In this case, with this PR implementation, the "Getting started with iOS SDK toolkit" anchor title will be a title of page as well


Ref https://github.com/docsifyjs/docsify/issues/540

Checklist:
* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
