### PR TITLE
chore: update german docs, fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="#backers"><img alt="Backers on Open Collective" src="https://opencollective.com/docsify/backers/badge.svg?style=flat-square"></a>
   <a href="#sponsors"><img alt="Sponsors on Open Collective" src="https://opencollective.com/docsify/sponsors/badge.svg?style=flat-square"></a>
-  <a href="https://travis-ci.org/QingWei-Li/docsify"><img alt="Travis Status" src="https://img.shields.io/travis/QingWei-Li/docsify/master.svg?style=flat-square"></a>
+  <a href="https://travis-ci.org/docsifyjs/docsify"><img alt="Travis Status" src="https://img.shields.io/travis/docsifyjs/docsify/master.svg?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/docsify"><img alt="npm" src="https://img.shields.io/npm/v/docsify.svg?style=flat-square"></a>
   <a href="https://github.com/QingWei-Li/donate"><img alt="donate" src="https://img.shields.io/badge/%24-donate-ff69b4.svg?style=flat-square"></a>
   <a href="https://gitter.im/docsifyjs/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link"><img alt="gitter" src="https://img.shields.io/gitter/room/docsifyjs/docsify.svg?style=flat-square"></a>
@@ -28,9 +28,9 @@
 ## Links
 
 - [Documentation](https://docsify.js.org)
-- [CLI](https://github.com/QingWei-Li/docsify-cli)
+- [CLI](https://github.com/docsifyjs/docsify-cli)
 - CDN: [UNPKG](https://unpkg.com/docsify/) | [jsDelivr](https://cdn.jsdelivr.net/npm/docsify/) | [cdnjs](https://cdnjs.com/libraries/docsify)
-- [Awesome docsify](https://github.com/QingWei-Li/awesome-docsify)
+- [Awesome docsify](https://github.com/docsifyjs/awesome-docsify)
 - [Community chat](https://gitter.im/docsifyjs/Lobby)
 
 ## Features
@@ -41,7 +41,7 @@
 - Multiple themes
 - Useful plugin API
 - Compatible with IE10+
-- Support SSR ([example](https://github.com/QingWei-Li/docsify-ssr-demo))
+- Support SSR ([example](https://github.com/docsifyjs/docsify-ssr-demo))
 - Support embedded files
 
 ## Quick start
@@ -52,7 +52,7 @@ Look at [this tutorial](https://docsify.js.org/#/quickstart) or [online demo](ht
 
 These projects are using docsify to generate their sites. Pull requests welcome :blush:
 
-Move to [awesome-docsify](https://github.com/QingWei-Li/awesome-docsify)
+Move to [awesome-docsify](https://github.com/docsifyjs/awesome-docsify)
 
 ## Similar projects
 
@@ -99,10 +99,10 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/QingWei-Li/docsify/graphs/contributors"><img src="https://opencollective.com/docsify/contributors.svg?width=890" /></a>
+<a href="https://github.com/docsifyjs/docsify/graphs/contributors"><img src="https://opencollective.com/docsify/contributors.svg?width=890" /></a>
 
 ## License
 
 MIT
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2FQingWei-Li%2Fdocsify.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2FQingWei-Li%2Fdocsify?ref=badge_large)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fdocsifyjs%2Fdocsify.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fdocsifyjs%2Fdocsify?ref=badge_large)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,11 +18,11 @@ See the [Quick start](quickstart.md) for more details.
 - Emoji support
 - Compatible with IE10+
 
-* Support SSR ([example](https://github.com/QingWei-Li/docsify-ssr-demo))
+* Support SSR ([example](https://github.com/docsifyjs/docsify-ssr-demo))
 
 ## Examples
 
-Check out the [Showcase](https://github.com/QingWei-Li/docsify/#showcase) to docsify in use.
+Check out the [Showcase](https://github.com/docsifyjs/docsify/#showcase) to docsify in use.
 
 ## Donate
 

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -8,5 +8,5 @@
 * No statically built html files
 * Multiple themes
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Get Started](#docsify)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ You can configure the `window.$docsify`.
 ```html
 <script>
   window.$docsify = {
-    repo: 'QingWei-Li/docsify',
+    repo: 'docsifyjs/docsify',
     maxLevel: 3,
     coverpage: true
   }
@@ -34,9 +34,9 @@ Configure the repository url or a string of `username/repo` can add the [GitHub 
 
 ```js
 window.$docsify = {
-  repo: 'QingWei-Li/docsify',
+  repo: 'docsifyjs/docsify',
   // or
-  repo: 'https://github.com/QingWei-Li/docsify/'
+  repo: 'https://github.com/docsifyjs/docsify/'
 };
 ```
 
@@ -127,7 +127,7 @@ window.$docsify = {
 
   // Or use the readme in your repo
   homepage:
-    'https://raw.githubusercontent.com/QingWei-Li/docsify/master/README.md'
+    'https://raw.githubusercontent.com/docsifyjs/docsify/master/README.md'
 };
 ```
 
@@ -268,7 +268,7 @@ window.$docsify = {
     '/foo/(+*)': '/bar/$1', // supports regexp
     '/zh-cn/changelog': '/changelog',
     '/changelog':
-      'https://raw.githubusercontent.com/QingWei-Li/docsify/master/CHANGELOG',
+      'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG',
     '/.*/_sidebar.md': '/_sidebar.md' // See #301
   }
 };
@@ -278,7 +278,7 @@ window.$docsify = {
 
 - type: `Boolean`
 
-If `loadSidebar` and `autoHeader` are both enabled, for each link in `_sidebar.md`, prepend a header to the page before converting it to html. Compare [#78](https://github.com/QingWei-Li/docsify/issues/78).
+If `loadSidebar` and `autoHeader` are both enabled, for each link in `_sidebar.md`, prepend a header to the page before converting it to html. Compare [#78](https://github.com/docsifyjs/docsify/issues/78).
 
 ```js
 window.$docsify = {
@@ -380,7 +380,7 @@ window.$docsify = {
 
 - type: `Array`
 
-Sometimes we do not want docsify to handle our links. See [#203](https://github.com/QingWei-Li/docsify/issues/203)
+Sometimes we do not want docsify to handle our links. See [#203](https://github.com/docsifyjs/docsify/issues/203)
 
 ```js
 window.$docsify = {

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -30,7 +30,7 @@ Set `coverpage` to **true**, and create a `_coverpage.md`:
 * No statically built html files
 * Multiple themes
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Get Started](#docsify)
 ```
 
@@ -45,7 +45,7 @@ The background color is generated randomly by default. You can customize the bac
 
 # docsify <small>3.5</small>
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Get Started](#quick-start)
 
 <!-- background image -->

--- a/docs/de-de/README.md
+++ b/docs/de-de/README.md
@@ -4,30 +4,33 @@
 
 ## Was ist das
 
-**docsify** generiert deine Dokumentationswebseite zeitgleich (mit der Darstellung). Im Gegensatz zu GitBook, werden keine statischen HTML Seiten generiert. Stattdessen, werden im Hintergrund Markdown Dateien geladen und umgewandelt, und als Webseite dargestellt. Alles, was du brauchst, ist eine Datei namens `index.html`, um sie über [GitHub Pages zu veröffentlichen](de-de/deploy.md).
+**docsify** generiert deine Dokumentationswebseite im Hintergrund.
+Im Gegensatz zu [GitBook](https://www.gitbook.com) werden hier keine statischen HTML Seiten generiert.
+Stattdessen, werden im Hintergrund [Markdown](https://de.wikipedia.org/wiki/Markdown) Dateien geladen, umgewandelt und als Webseite dargestellt. Alles, was du brauchst, ist eine Datei namens `index.html`, um sie über [GitHub Pages zu veröffentlichen](de-de/deploy.md).
 
 Siehe [Schnellstart](de-de/quickstart.md) für weitere Informationen.
 
-## Features
+## Besonderheiten
 
-- keine generierten, statischen HTML Dateien
-- einfach und klein (~19kB gzipped)
-- smarte Erweiterung mit Volltextsuche
+- keine statisch generierten HTML Dateien
+- einfach und klein (~ 19kB gzipped)
+- smarte Volltextsuche als Erweiterung verfügbar
 - mehrere Themes
-- praktische API für Erweiterungen
+- praktische API für (eigene) Erweiterungen
 - Unterstützung für Emoji
-- Kompatibel mit IE10+
-
-* Support SSR ([example](https://github.com/QingWei-Li/docsify-ssr-demo))
+- Kompatibel mit `IE10+`
+- Unterstützt SSR ([Beispiel](https://github.com/docsifyjs/docsify-ssr-demo))
 
 ## Beispiele
 
-Vergleiche die Liste namens [Showcase](https://github.com/QingWei-Li/docsify/#showcase) mit Beispielen, wie **docsify** verwendet wird.
+Vergleiche die Liste namens [Showcase](https://github.com/docsifyjs/docsify/#showcase) mit Beispielen, wie **docsify** verwendet wird.
 
 ## Spenden
 
-Bitte ziehe eine Spende in Erwägung, sollte **docsify** dir hilfreich oder meine Arbeit dir wertvoll erscheinen. Ich freue mich, wenn du mir [eine Tasse Kaffee kaufst](https://github.com/QingWei-Li/donate). :heart:
+Bitte ziehe eine Spende in Erwägung, sollte **docsify** dir hilfreich oder meine Arbeit dir wertvoll erscheinen.
+Ich freue mich, wenn du mir [eine Tasse Kaffee kaufst](https://github.com/QingWei-Li/donate).
+:heart:
 
 ## Community
 
-Users and development team are in the [Gitter](https://gitter.im/docsifyjs/Lobby).
+Andere Benutzer und das Entwickler-Team kannst du über [Gitter](https://gitter.im/docsifyjs/Lobby) treffen.

--- a/docs/de-de/_sidebar.md
+++ b/docs/de-de/_sidebar.md
@@ -1,28 +1,28 @@
-* Loslegen
+- Loslegen
 
-  * [Schnellstart](de-de/quickstart.md)
-  * [Schreiben weiterer Seiten](de-de/more-pages.md)
-  * [Navigationsleiste anpassen](de-de/custom-navbar.md)
-  * [Titelseite](de-de/cover.md)
+  - [Schnellstart](de-de/quickstart.md)
+  - [Schreiben weiterer Seiten](de-de/more-pages.md)
+  - [Navigationsleiste anpassen](de-de/custom-navbar.md)
+  - [Titelseite](de-de/cover.md)
 
-* Anpassen
+- Anpassen
 
-  * [Einstellungen](de-de/configuration.md)
-  * [Themen](de-de/themes.md)
-  * [Liste der Erweiterungen](de-de/plugins.md)
-  * [Schreiben eigener Erweiterungen](de-de/write-a-plugin.md)
-  * [Markdown-Einstellungen](de-de/markdown.md)
-  * [Hervorheben von Sprachen](de-de/language-highlight.md)
+  - [Einstellungen](de-de/configuration.md)
+  - [Themen](de-de/themes.md)
+  - [Liste der Erweiterungen](de-de/plugins.md)
+  - [Schreiben eigener Erweiterungen](de-de/write-a-plugin.md)
+  - [Markdown-Einstellungen](de-de/markdown.md)
+  - [Hervorheben von Sprachen](de-de/language-highlight.md)
 
-* Guide
+- Handbuch
 
-  * [Inbetriebnahme](de-de/deploy.md)
-  * [Helfer](de-de/helpers.md)
-  * [Vue Kompatibilität](de-de/vue.md)
-  * [CDN](de-de/cdn.md)
-  * [Offline Modus (PWA)](de-de/pwa.md)
-  * [Server-Side Rendering (SSR)](de-de/ssr.md)
-  * [Embed Files <sup style="color:red">(new)<sup>](de-de/embed-files.md)
+  - [Inbetriebnahme](de-de/deploy.md)
+  - [Helfer](de-de/helpers.md)
+  - [Vue Kompatibilität](de-de/vue.md)
+  - [CDN](de-de/cdn.md)
+  - [Offline Modus (PWA)](de-de/pwa.md)
+  - [Server-Side Rendering (SSR)](de-de/ssr.md)
+  - [Einbinden von Dateien <sup style="color:red">(neu)<sup>](de-de/embed-files.md)
 
-* [Awesome docsify](de-de/awesome.md)
-* [Changelog](de-de/changelog.md)
+- [Awesome docsify](de-de/awesome.md)
+- [Changelog](de-de/changelog.md)

--- a/docs/de-de/cdn.md
+++ b/docs/de-de/cdn.md
@@ -1,6 +1,10 @@
 # CDN
 
-Empfohlen: [unpkg](//unpkg.com), welches jeweils die aktuelle Version liefert, wie sie über npm veröffentlicht wurde. Du kannst auch den Quellcode des npm Packets über [unpkg.com/docsify/](//unpkg.com/docsify/) anschauen.
+> content delivery network = Netzwerk zur Verteilung von Inhalten
+
+Empfohlen:
+[unpkg](https://unpkg.com), welches jeweils die aktuelle Version liefert, wie sie über npm veröffentlicht wurde.
+Du kannst den Quellcode des npm Packets auch über [unpkg.com/docsify/](https://unpkg.com/docsify/) anschauen.
 
 ## Aktuelle Version
 
@@ -14,7 +18,7 @@ Empfohlen: [unpkg](//unpkg.com), welches jeweils die aktuelle Version liefert, w
 
 Alternativ kannst du auch die [komprimierten Dateien](#komprimierte-dateien) verwenden.
 
-## Spezielle Version
+## Spezifische Versionen
 
 ```html
 <!-- lade CSS -->
@@ -34,6 +38,8 @@ Alternativ kannst du auch die [komprimierten Dateien](#komprimierte-dateien) ver
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 ```
 
+oder auch:
+
 ```html
 <!-- lade CSS -->
 <link rel="stylesheet" href="//unpkg.com/docsify@2.0.0/lib/themes/vue.css">
@@ -44,6 +50,6 @@ Alternativ kannst du auch die [komprimierten Dateien](#komprimierte-dateien) ver
 
 ## Andere CDN
 
-- http://www.bootcdn.cn/docsify
-- https://cdn.jsdelivr.net/npm/docsify/
-- https://cdnjs.com/libraries/docsify
+- <http://www.bootcdn.cn/docsify>
+- <https://cdn.jsdelivr.net/npm/docsify/>
+- <https://cdnjs.com/libraries/docsify>

--- a/docs/de-de/configuration.md
+++ b/docs/de-de/configuration.md
@@ -1,11 +1,11 @@
 # Einstellungen
 
-You can configure the `window.$docsify`.
+Du kannst Einstellungen für `window.$docsify` wie folgt ändern:
 
 ```html
 <script>
   window.$docsify = {
-    repo: 'QingWei-Li/docsify',
+    repo: 'docsifyjs/docsify',
     maxLevel: 3,
     coverpage: true
   }
@@ -17,7 +17,8 @@ You can configure the `window.$docsify`.
 - Typ: `String`
 - Standard: `#app`
 
-Das DOM Element kann bei der Initialisierung gesetzt werden. Es kann ein CSS selector string oder ein richtiges HTMLElement sein.
+Das DOM Element kann bei der Initialisierung gesetzt werden.
+Es kann ein CSS selector string oder ein richtiges HTML Element sein.
 
 ```js
 window.$docsify = {
@@ -30,13 +31,13 @@ window.$docsify = {
 - Typ: `String`
 - Standard: `null`
 
-Verwende die repository URL oder eine Zeichenfolge aus `Benutzername/repo`, um das [GitHub Corner](http://tholman.com/github-corners/) widget in die obere rechte Ecke der Seite zu implementieren.
+Verwende die repository URL oder eine Zeichenfolge aus `Benutzername/repo`, um das [GitHub Corner](http://tholman.com/github-corners/) widget in der oberen rechten Ecke der Seite zu implementieren.
 
 ```js
 window.$docsify = {
-  repo: 'QingWei-Li/docsify',
+  repo: 'docsifyjs/docsify',
   // oder
-  repo: 'https://github.com/QingWei-Li/docsify/'
+  repo: 'https://github.com/docsifyjs/docsify/'
 };
 ```
 
@@ -127,7 +128,7 @@ window.$docsify = {
 
   // Oder verwende das README in deinem repo
   homepage:
-    'https://raw.githubusercontent.com/QingWei-Li/docsify/master/README.md'
+    'https://raw.githubusercontent.com/docsifyjs/docsify/master/README.md'
 };
 ```
 
@@ -179,7 +180,8 @@ window.$docsify = {
 
 - Type: `String`
 
-Website logo as it appears in the sidebar, you can resize by CSS.
+Das Webseitenlogo, wie es in der Sidebar erscheint.
+Du kannst seine Größe mit CSS ändern.
 
 ```js
 window.$docsify = {
@@ -268,7 +270,7 @@ window.$docsify = {
     '/foo/(+*)': '/bar/$1', // supports regexp
     '/zh-cn/changelog': '/changelog',
     '/changelog':
-      'https://raw.githubusercontent.com/QingWei-Li/docsify/master/CHANGELOG',
+      'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG',
     '/.*/_sidebar.md': '/_sidebar.md' // See #301
   }
 };
@@ -278,7 +280,7 @@ window.$docsify = {
 
 - Typ: `Boolean`
 
-Sollten `loadSidebar` und `autoHeader` beide aktiviert sein, setze einen Header vor die Seite in jedem Link in `_sidebar.md`, bevor sie in HTML umgewandelt wird. Vergleiche [#78](https://github.com/QingWei-Li/docsify/issues/78).
+Sollten `loadSidebar` und `autoHeader` beide aktiviert sein, setze einen Header vor die Seite in jedem Link in `_sidebar.md`, bevor sie in HTML umgewandelt wird. Vergleiche [#78](https://github.com/docsifyjs/docsify/issues/78).
 
 ```js
 window.$docsify = {
@@ -313,7 +315,7 @@ window.$docsify = {
 
 - type: `Boolean`
 
-Verhindere die Umwandlung in Emojis:
+Verhindere die Umwandlung in Emoji:
 
 ```js
 window.$docsify = {
@@ -337,8 +339,10 @@ window.$docsify = {
 
 - type: `String|Function`
 
-We can display the file update date through **{docsify-updated<span>}</span>** variable. And format it by `formatUpdated`.
-See https://github.com/lukeed/tinydate#patterns
+Du kannst das Datum der letzten Änderung mithilfe der Variable **`{docsify-updated}`** anzeigen.
+Dessen Format kannst du über `formatUpdated` in den Einstellungen ändern wie folgt ändern:
+
+Siehe auch <https://github.com/lukeed/tinydate#patterns>
 
 ```js
 window.$docsify = {
@@ -357,7 +361,7 @@ window.$docsify = {
 - type: `String`
 - default: `_blank`
 
-Currently it defaults to \_blank, would be nice if configurable:
+Das Ziel externer Links. Standard ist `_blank` (neues Fenster / neuer Tab):
 
 ```js
 window.$docsify = {
@@ -380,7 +384,7 @@ window.$docsify = {
 
 - type: `Array`
 
-Sometimes we do not want docsify to handle our links. See [#203](https://github.com/QingWei-Li/docsify/issues/203)
+Manchmal möchten wir nicht, dass `docsify` die Verwaltung unserer Links übernimmt, vergleiche [#203](https://github.com/docsifyjs/docsify/issues/203).
 
 ```js
 window.$docsify = {
@@ -392,7 +396,7 @@ window.$docsify = {
 
 - type: `Object`
 
-Set the request resource headers.
+Ändere die Header für Anfragen.
 
 ```js
 window.$docsify = {
@@ -406,7 +410,7 @@ window.$docsify = {
 
 - type: `String`
 
-Request file extension.
+Dateiendung für Anfragen.
 
 ```js
 window.$docsify = {
@@ -418,13 +422,13 @@ window.$docsify = {
 
 - type: `Array<string>`
 
-List of languages that will fallback to the default language when a page is request and didn't exists for the given local.
+Liste der Sprachen, für die bei angefragten Seiten, welche nicht gefunden wurden, auf die Seiten der Standardsprache zurückgegriffen wird.
 
-Example:
+Beispiel der Abfolge von Anfragen:
 
-- try to fetch the page of `/de/overview`. If this page exists, it'll be displayed
-- then try to fetch the default page `/overview` (depending on the default language). If this page exists, it'll be displayed
-- then display 404 page.
+- Versuch einer Anfrage für `/de/overview`. Wenn sie existiert, wird sie angezeigt.
+- Danach Versuch einer Anfrage an `/overview` (abhängig von der Standardsprache). Darstellung dieser, wenn sie existiert.
+- Danach Anzeige der 404 (Fehler-) Seite.
 
 ```js
 window.$docsify = {
@@ -436,7 +440,7 @@ window.$docsify = {
 
 - type: `Boolean` | `String` | `Object`
 
-Load the `_404.md` file:
+Lade die `_404.md` Datei:
 
 ```js
 window.$docsify = {
@@ -444,7 +448,7 @@ window.$docsify = {
 };
 ```
 
-Load the customised path of the 404 page:
+Lade einen eigens definierten Zielpfad für die 404 Seite:
 
 ```js
 window.$docsify = {
@@ -452,7 +456,7 @@ window.$docsify = {
 };
 ```
 
-Load the right 404 page according to the localisation:
+Lade die richtige 404 Seite abhängig von der aktuellen Sprache:
 
 ```js
 window.$docsify = {
@@ -463,4 +467,4 @@ window.$docsify = {
 };
 ```
 
-> Note: The options with fallbackLanguages didn't work with the `notFoundPage` options.
+> Notiz: Die Einstellungen für `fallbackLanguages` funktionieren aktuell nicht bei gleichzeitiger Verwendung von `notFoundPage`.

--- a/docs/de-de/cover.md
+++ b/docs/de-de/cover.md
@@ -22,7 +22,7 @@ Setze `coverpage` auf **true**, und erstelle `_coverpage.md`:
 
 ![logo](_media/icon.svg)
 
-# docsify <small>3.5</small>
+# docsify <small>4.7.0</small>
 
 > Ein magischer Generator für Dokumentationsseiten.
 
@@ -30,7 +30,7 @@ Setze `coverpage` auf **true**, und erstelle `_coverpage.md`:
 * Keine statischen HTML Dateien
 * Mehrere Themes
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Schnellstart](#docsify)
 ```
 
@@ -38,14 +38,15 @@ Setze `coverpage` auf **true**, und erstelle `_coverpage.md`:
 
 ## Eigener Hintergrund
 
-Die Hintergrundfarbe wird in der Standardeinstellung zufällig generiert. Du kannst sie anpassen, oder auch ein Hintergrundbild verwenden:
+Die Hintergrundfarbe wird in der Standardeinstellung zufällig generiert.
+Du kannst sie anpassen, oder auch ein Hintergrundbild verwenden:
 
 ```markdown
 <!-- _coverpage.md -->
 
-# docsify <small>3.5</small>
+# docsify <small>4.7.0</small>
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Schnellstart](#quick-start)
 
 <!-- Hintegrundbild -->
@@ -57,15 +58,16 @@ Die Hintergrundfarbe wird in der Standardeinstellung zufällig generiert. Du kan
 ![color](#f0f0f0)
 ```
 
-## Coverpage as homepage
+## Titelseite als Startseite
 
-Normal, the coverpage and the homepage appear at the same time. Of course, you can also separate the coverpage by [onlyCover option](de-de/configuration.md#onlycover).
+Für gewöhnlich werden die Titelseite und die Startseite zusammen auf einer Seite angezeigt.
+Diese kann man natürlich auch mit der [`onlyCover` Einstellung](de-de/configuration.md#onlycover) ändern.
 
-## Multiple covers
+## Mehrere Titelseiten
 
-If your docs site is in more than one language, it may be useful to set multiple covers.
+Sollte deine Dokumentation in mehreren Sprachen zur Verfügung stehen, macht es Sinn, auch mehrere Titelseiten zu erstellen.
 
-For example, your docs structure is like this
+Für folgende Struktur:
 
 ```text
 .
@@ -73,27 +75,27 @@ For example, your docs structure is like this
     ├── README.md
     ├── guide.md
     ├── _coverpage.md
-    └── zh-cn
+    └── de-de
         ├── README.md
         └── guide.md
         └── _coverpage.md
 ```
 
-Now, you can set
+definiere wie folgt:
 
 ```js
 window.$docsify = {
-  coverpage: ['/', '/zh-cn/']
+  coverpage: ['/', '/de-de/']
 };
 ```
 
-Or a special file name
+oder bei Verwendung abweichender Dateinamen:
 
 ```js
 window.$docsify = {
   coverpage: {
     '/': 'cover.md',
-    '/zh-cn/': 'cover.md'
+    '/de-de/': 'cover.md'
   }
 };
 ```

--- a/docs/de-de/custom-navbar.md
+++ b/docs/de-de/custom-navbar.md
@@ -42,9 +42,11 @@ Oder du kannst deine Navigationsleiste mit einer Datei basierend auf Markdown er
 
 !> Solltest du Github Pages verwenden, musst du zusätzlich eine Datei namens `.nojekyll` in `./docs` erstellen, um zu verhindern, dass Github Dateien ignoriert, die mit einem Unterstrich anfangen.
 
-`_navbar.md` wird in jedem Verzeichnislevel geladen. Sollte das aktuelle Verzeichnis keine Datei namens `_navbar.md` haben, so sucht **docsify** in den übergeordneten Ordnern. Wenn du z.B. im Moment im Verzeichnis `/guide/quick-start` bist, so wird `_navbar.md` von der Datei `/guide/_navbar.md` geladen.
+`_navbar.md` wird in jedem Verzeichnislevel geladen.
+Sollte das aktuelle Verzeichnis keine Datei namens `_navbar.md` haben, so sucht **docsify** in den übergeordneten Ordnern.
+Wenn du z.B. im Moment im Verzeichnis `/guide/quick-start` bist, so wird `_navbar.md` von der Datei `/guide/_navbar.md` geladen.
 
-## Aufbauen von Strukturen
+## Verschachtelung
 
 Du kannst untergeordnete Listen erstellen, indem du untergeordnete Punkte einem übergeordneten Punkt gegenüber einrückst.
 
@@ -68,9 +70,9 @@ Du kannst untergeordnete Listen erstellen, indem du untergeordnete Punkte einem 
 
 wird also wie folgt aussehen
 
-![Nesting navbar](../_images/nested-navbar.png 'Nesting navbar')
+![Verschachtelte navbar](../_images/nested-navbar.png 'Verschachtelte navbar')
 
-## Angepasste Navigationsleisten in Verbindung mit dem emoji Erweiterung
+## Verbindung von eigens angepassten Navigationsleisten mit der emoji Erweiterung
 
 Solltest du die [emoji Erweiterung](plugins.md#emoji) verwenden:
 

--- a/docs/de-de/deploy.md
+++ b/docs/de-de/deploy.md
@@ -1,26 +1,26 @@
 # Inbetriebnahme
 
-Ähnlich wie bei [GitBook](https://www.gitbook.com), kannst du deine Dateien über GitHub Pages oder VPS erstellen.
+Ähnlich wie bei [GitBook](https://www.gitbook.com), kannst du deine Dateien über [GitHub Pages](https://pages.github.com), [Gitlab Pages](https://about.gitlab.com/features/pages) oder VPS erstellen.
 
 ## GitHub Pages
 
-Du kannst folgende drei Orte verwenden, um die Dokumentation für dein Github repository zu verwalten:
+Bei der Verwendung von [GitHub Pages](https://pages.github.com) kannst du folgende drei Orte verwenden, um die Dokumentation für dein GitHub repository zu verwalten:
 
 - `docs/` Ordner
 - master branch
 - gh-pages branch
 
-Es wird empfohlen, deine Dateien im `./docs` Unterordner im `master` branch deines repository zu speichern. Wechsle dann zu den Einstellungen deines repository und wähle `master branch /docs folder` als deine Github Pages Quelle.
+Es wird empfohlen, deine Dateien im `./docs` Unterordner im `master` branch deines repository zu speichern. Wechsle dann zu den Einstellungen deines repository und wähle `master branch /docs folder` als deine [GitHub Pages](https://pages.github.com) Quelle.
 
-![github pages](../_images/deploy-github-pages.png)
+![GitHub Pages](../_images/deploy-github-pages.png)
 
 !> Du kannst die Dateien auch im Hauptverzeichnis speichern und dann `master branch` in den Einstellungen auswählen.
 
 ## GitLab Pages
 
-If you are deploying your master branch, include `.gitlab-ci.yml` with the following script:
+Wenn du mit [GitLab Pages](https://about.gitlab.com/features/pages) über den master branch deployst, verwende eine `.gitlab-ci.yml` Datei mit folgendem Code:
 
-?> The `.public` workaround is so `cp` doesn't also copy `public/` to itself in an infinite loop.
+?> Der Trick mit dem `.public` Verzeichnis wird verwendet, damit `cp` nicht auch `public/` in sich selbst in einer ewigen Schleife kopiert.
 
 ```YAML
 pages:
@@ -36,11 +36,31 @@ pages:
   - master
 ```
 
-!> You can replace script with `- cp -r docs/. public`, if `./docs` is your Docsify subfolder.
+!> Du kannst auch script mit `- cp -r docs/. public`, sollte `./docs` dein **docsify** Unterverzeichnis sein.
+
+## Firebase Hosting
+
+!> Du musst das Firebase CLI mithilfe von `npm i -g firebase-tools` installieren, nachdem du dich unter [Firebase Console](https://console.firebase.google.com) mit einem Google Konto angemeldet hast.
+
+Verwende das Terminal, um das Unterverzeichnis deines Firebase Projektes zu finden und anzusteuern - es könnte z.B. `~/Projects/Docs` sein. Führe dort `firebase init` aus, dann wähle `Hosting` über das Menü (verwende Leerzeichen, um auszuwählen, Pfeiltasten, um die Einstellungen zu ändern, and die Entertaste, um zu bestätigen). Folge den Anweisungen für die Einrichtung.
+
+Deine `firebase.json` Datei sollte wie folgt aussehen (Ich habe mein deploy Verzeichnis von `public` zu `site` geändert):
+
+```json
+{
+  "hosting": {
+    "public": "site",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+  }
+}
+```
+
+Sobald du fertig bist, baue die Vorlage, indem du `docsify init ./site` ausführst (ersetze `site` mit deinem deployment Verzeichnis, welches du beim Ausführen von `firebase init` gewählt hast - `public` ist hier die Standardeinstellung).
+Nimm Änderungen an deiner Dokumentation vor und führe `firebase deploy` in dem Verzeichnis deines Projektes aus.
 
 ## VPS
 
-Verwende folgende nginx config.
+Versuche es mit folgender nginx Einstellung:
 
 ```nginx
 server {
@@ -56,13 +76,13 @@ server {
 
 ## Netlify
 
-1.  Login to your [Netlify](https://www.netlify.com/) account.
-2.  In the [dashboard](https://app.netlify.com/) page, click **New site from Git**.
-3.  Choose a repository where you store your docs, leave the **Build Command** area blank, fill in the Publish directory area with the directory of your `index.html`, for example it should be docs if you populated it at `docs/index.html`.
+1. Melde dich mit deinem [Netlify](https://www.netlify.com/) Konto an.
+2. In den [Einstellungen](https://app.netlify.com/) wähle **New site from Git**.
+3. Wähle das Verzeichnis, in dem du deine Dokumentation erstellst. Lasse **Build Command** leer, und wähle für die Einstellung **publish directory** jenes Unterverzeichnis, in welchem sich die Datei `index.html` von **docsify** für deine Dokumentation befindet. Meistens ist dies `docs`, weil `docs/index.html`.
 
 ### HTML5 router
 
-When using the HTML5 router, you need to set up redirect rules that redirect all requests to your `index.html`, it's pretty simple when you're using Netlify, populate a `\redirects` file in the docs directory and you're all set:
+Bei der Verwendung des HTML5 router musst du Umleitungsregeln erstellen, die alle Anfragen an `index.html` umleitet. Mit Netlify ist dies einfach. Erstelle eine `\redirects` Datei im `docs` Unterverzeichnis mit:
 
 ```sh
 /*    /index.html   200

--- a/docs/de-de/embed-files.md
+++ b/docs/de-de/embed-files.md
@@ -1,27 +1,27 @@
-# Embed files
+# Einbinden von Dateien
 
-With docsify 4.6 it is now possible to embed any type of file.
-You can embed these files as video, audio, iframes, or code blocks, and even Markdown files can even be embedded directly into the document.
+Mit docsify `4.6` ist es jetzt möglich, jede Art von Datei einzubinden.
+Du kannst Dateien als Video, Audio, iframes oder Code Blöcke einbinden. Markdown Dateien können sogar direkt eingebunden werden.
 
-For example, here embedded a Markdown file. You only need to do this:
+Als Beispiel binden wir hier eine Markdown Datei ein:
 
 ```markdown
-[filename](../_media/example.md ':include')
+[Dateiname](_media/example.md ':include')
 ```
 
-Then the content of `example.md` will be displayed directly here
+Dabei wird der Inhalt der Datei `example.md` direkt eingebunden. Zum Beispiel wie folgt:
 
-[filename](../_media/example.md ':include')
+[Dateiname](_media/example.md ':include')
 
-You can check the original content for [example.md](../_media/example.md ':ignore').
+Vergleiche diesen Link: [example.md](_media/example.md ':ignore').
 
-Normally, this will compiled into a link, but in docsify, if you add `:include` it will be embedded.
+Für gewöhnlich wäre dies ein Link. Bei der Verwendung von `:include` bindet **`docsify`** diese Datei jedoch direkt ein.
 
-## Embedded file type
+## Einbinden bestimmter Dateitypen
 
-Currently, file extension are automatically recognized and embedded in different ways.
+Aktuell werden Dateiendungen automatisch erkannt. **docsify** bindet abhängig davon Dateien unterschiedlich ein.
 
-This is a supported embedding type:
+Unterstützt werden derzeit:
 
 * **iframe** `.html`, `.htm`
 * **markdown** `.markdown`, `.md`
@@ -29,19 +29,19 @@ This is a supported embedding type:
 * **video** `.mp4`, `.ogg`
 * **code** other file extension
 
-Of course, you can force the specified. For example, you want to Markdown file as code block embedded.
+Natürlich kannst du auch einen bestimmten Typ bei der Einbindung einer Datei erzwingen:
 
 ```markdown
-[filename](../_media/example.md ':include :type=code')
+[Dateiname](_media/example.md ':include :type=code')
 ```
 
-You will get it
+Obiges Beispiel hier:
 
-[filename](../_media/example.md ':include :type=code')
+[Dateiname](_media/example.md ':include :type=code')
 
 ## Tag attribute
 
-If you embed the file as `iframe`, `audio` and `video`, then you may need to set the attributes of these tags.
+Wenn du eine Datei als `iframe`, `audio` oder `video` einbindest, kann dies das Definieren bestimmter Attribute erfordern.
 
 ```markdown
 [cinwell website](https://cinwell.com ':include :type=iframe width=100% height=400px')
@@ -49,18 +49,18 @@ If you embed the file as `iframe`, `audio` and `video`, then you may need to set
 
 [cinwell website](https://cinwell.com ':include :type=iframe width=100% height=400px')
 
-Did you see it? You only need to write directly. You can check [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) for these attributes.
+Hast du die Seite gesehen? Du kannst also direkt über einen Markdown-Link Webseiten einfügen. Vergleiche [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) für eine Liste von Attributen.
 
-## The code block highlight
+## Hervorhebung von Code Blöcken
 
-Embedding any type of source code file, you can specify the highlighted language or automatically identify.
+Beim Einbinden von Source Code Dateien jeglichen Typs kannst du die hervorgehobene Sprache automatisch erkennen lassen oder auch selbst definieren.
 
 ```markdown
-[](../_media/example.html ':include :type=code text')
+[](_media/example.html ':include :type=code text')
 ```
 
 ⬇️
 
-[](../_media/example.html ':include :type=code text')
+[](_media/example.html ':include :type=code text')
 
-?> How to set highlight? You can see [here](language-highlight.md).
+?> Wie genau ging das nochmal mit der Hervorhebung? Vergleiche [diese Seite](language-highlight.md).

--- a/docs/de-de/helpers.md
+++ b/docs/de-de/helpers.md
@@ -26,23 +26,24 @@ wird wie folgt gerendert:
 
 ?> _TODO_ unit test
 
-## Ignore to compile link
+## Ignorieren bestimmter Links beim Kompilieren
 
-Some time we will put some other relative path to the link, you have to need to tell docsify you don't need to compile this link. For example
+Manchmal möchten wir einen bestimmten relativen Pfad als Link. Dazu müssen wir **docsify** anweisen, diesen Link nicht zu kompilieren.
+Als Beispiel:
 
 ```md
 [link](/demo/)
 ```
 
-It will be compiled to `<a href="/#/demo/">link</a>` and will be loaded `/demo/README.md`. Maybe you want to jump to `/demo/index.html`.
+Daraus wird `<a href="/#/demo/">link</a>` und **docsify** lädt dann `/demo/README.md`. Vielleicht wolltest du aber zu `/demo/index.html`?
 
-Now you can do that
+Ändere deinen Link also zu:
 
 ```md
 [link](/demo/ ':ignore')
 ```
 
-You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set title for link.
+Nun erhälst du den Link `<a href="/demo/">link</a>`. Einen Titel kannst du wie folgt einstellen:
 
 ```md
 [link](/demo/ ':ignore title')
@@ -50,11 +51,17 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 <a href="/demo/" title="title">link</a>
 ```
 
-## Set target attribute for link
+## Setze ein target attribute für deinen Link
 
 ```md
 [link](/demo ':target=_blank')
 [link](/demo2 ':target=_self')
+```
+
+## Links deaktivieren
+
+```md
+[link](/demo ':disable')
 ```
 
 ## Github Task Lists
@@ -63,7 +70,7 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 - [ ] foo
 - bar
 - [x] baz
-- [] bam <~ not working
+- [] bam <~ funktioniert nicht
   - [ ] bim
   - [ ] lim
 ```
@@ -71,11 +78,11 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 - [ ] foo
 - bar
 - [x] baz
-- [] bam <~ not working
+- [] bam <~ funktioniert nicht
   - [ ] bim
   - [ ] lim
 
-## Image resizing
+## Größe von Bildern ändern
 
 ```md
 ![logo](https://docsify.js.org/_media/icon.svg ':size=50x100')

--- a/docs/de-de/markdown.md
+++ b/docs/de-de/markdown.md
@@ -30,10 +30,10 @@ window.$docsify = {
 ```
 
 
-## Supports mermaid
+## mermaid Unterstützung
 
 ```js
-// Import mermaid
+// Importiere mermaid
 //  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.css">
 //  <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 

--- a/docs/de-de/more-pages.md
+++ b/docs/de-de/more-pages.md
@@ -1,6 +1,7 @@
 # Noch mehr Seiten
 
-Wenn du mehr Seiten für deine Dokumentation brauchst, so kannst du weitere Markdown Dateien in deinem **docsify** Ordner erstellen. Eine Datei namens `guide.md` ist dann über `/#/guide` erreichbar.
+Wenn du mehr Seiten für deine Dokumentation brauchst, so kannst du weitere Markdown Dateien in deinem **docsify** Ordner erstellen.
+Eine Datei namens `guide.md` ist dann über `/#/guide` erreichbar.
 
 Nehmen wir als Beispiel folgende Verzeichnisstruktur:
 
@@ -25,7 +26,8 @@ docs/de-de/guide.md   => http://domain.com/de-de/guide
 
 ## Seitenleiste mit Inhaltsverzeichnis anpassen
 
-Als Standardeinstellung wird das Inhaltsverzeichnis in der Seitenleiste automatisch basierend auf vorhandenen Markdown Dateien generiert. Wenn du das seitliche Inhaltsverzeichnis anpassen willst, kannst du eine Datei namens `_sidebar.md` erstellen (vergleiche [das seitliche Inhaltsverzeichnis für diese Dokumentation](https://github.com/QingWei-Li/docsify/blob/master/docs/de-de/_sidebar.md) als Beispiel):
+Als Standardeinstellung wird das Inhaltsverzeichnis in der Seitenleiste automatisch basierend auf vorhandenen Markdown Dateien generiert.
+Wenn du das seitliche Inhaltsverzeichnis anpassen willst, kannst du eine Datei namens `_sidebar.md` erstellen (vergleiche [das seitliche Inhaltsverzeichnis für diese Dokumentation](https://github.com/docsifyjs/docsify/blob/master/docs/de-de/_sidebar.md) als Beispiel):
 
 Als Erstes musst du `loadSidebar` auf **true** setzen, vergleiche [Einstellungen für das seitliche Inhaltsverzeichnis](configuration.md#loadsidebar).
 
@@ -53,7 +55,7 @@ Als Zweites erstellst du eine Datei namens `_sidebar.md`:
 
 `_sidebar.md` wird in jedem Verzeichnislevel geladen. Sollte das aktuelle Verzeichnis keine Datei namens `_sidebar.md` haben, so sucht **docsify** in den übergeordneten Ordnern. Wenn du z.B. im Moment im Verzeichnis `/guide/quick-start` bist, so wird `_sidebar.md` von der Datei `/guide/_sidebar.md` geladen.
 
-You can specify `alias` to avoid unnecessary fallback.
+Du kannst `alias` definieren, um einen überflüssigen fallback zu vermeiden.
 
 ```html
 <script>
@@ -82,9 +84,10 @@ Eine angepasste Seitenleist kann auch automatisch ein Inhaltsverzeichnis generie
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 ```
 
-## Ignoring Subheaders
+## Ignorieren vun untergeordneten Überschriften
 
-When `subMaxLevel` is set, each header is automatically added to the table of contents by default. If you want to ignore a specific header, add `{docsify-ignore}` to it.
+Wenn `subMaxLevel` definiert ist, wird jede Überschrift in der Standardeinstellung zum Inhaltsverzeichnis hinzugefügt.
+Wenn du bestimmte Überschriften ignorieren möchtest, füge ihnen **`{docsify-ignore}`** hinzu.
 
 ```markdown
 # Getting Started
@@ -94,7 +97,7 @@ When `subMaxLevel` is set, each header is automatically added to the table of co
 This header won't appear in the sidebar table of contents.
 ```
 
-To ignore all headers on a specific page, you can use `{docsify-ignore-all}` on the first header of the page.
+Um alle Überschriften auf einer Seite zu ignorieren, füge der ersten Überschrift auf der Seite **`{docsify-ignore-all}`** hinzu.
 
 ```markdown
 # Getting Started {docsify-ignore-all}
@@ -104,4 +107,4 @@ To ignore all headers on a specific page, you can use `{docsify-ignore-all}` on 
 This header won't appear in the sidebar table of contents.
 ```
 
-Both `{docsify-ignore}` and `{docsify-ignore-all}` will not be rendered on the page when used.
+Beide Variablen, sowohl **`{docsify-ignore}`** als auch **`{docsify-ignore-all}`**, werden auf der Seite nicht gerendert (angezeigt).

--- a/docs/de-de/plugins.md
+++ b/docs/de-de/plugins.md
@@ -96,31 +96,31 @@ Exclude the special image
 ![](image.png ':no-zoom')
 ```
 
-## Demo code with instant preview and jsfiddle integration
+## Auf GitHub ändern
 
-With this plugin, sample code can be rendered on the page instantly, so that the readers can see the preview immediately.
-When readers expand the demo box, the source code and description are shown there. if they click the button `Try in Jsfiddle`,
-`jsfiddle.net` will be open with the code of this sample, which allow readers to revise the code and try on their own.
+Fügen deinen Seiten einen `Ändere diese Seite auf GitHub` Button hinzu. Zur Verfügung gestellt von [@njleonzhang](https://github.com/njleonzhang), siehe [njleonzhang/docsify-edit-on-github](https://github.com/njleonzhang/docsify-edit-on-github)
 
-[Vue](https://njleonzhang.github.io/docsify-demo-box-vue/) and [React](https://njleonzhang.github.io/docsify-demo-box-react/) are both supported.
+## Beispielcode mit direkter Vorschau und Integration mit jsfiddle
 
-## Edit on github
+Mit dieser Erweiterung kann Beispielcode auf einer Seite mit einer zugehörigen Vorschau direkt angezeigt werden.
 
-Add `Edit on github` button on every pages. Provided by [@njleonzhang](https://github.com/njleonzhang), check [document](https://github.com/njleonzhang/docsify-edit-on-github)
+Beim Erweitern des Demobereichs werden Quellcode und Beschreibungen mit einem `Try in Jsfiddle` Button dort angezeigt, über den man den Code selbst anpassen und ausprobieren kann.
 
-## Copy to Clipboard
+[Vue](https://njleonzhang.github.io/docsify-demo-box-vue/) und [React](https://njleonzhang.github.io/docsify-demo-box-react/) werden beide unterstützt.
 
-Add a simple `Click to copy` button to all preformatted code blocks to effortlessly allow users to copy example code from your docs. Provided by [@jperasmus](https://github.com/jperasmus)
+## Kopiere in Zwischenablage
+
+Füge den Quellcode-Blöcken auf deinen Seiten einen einfachen `Click to copy` Button hinzu. Zur Verfügung gestellt von [@jperasmus](https://github.com/jperasmus)
 
 ```html
 <script src="//unpkg.com/docsify-copy-code"></script>
 ```
 
-See [here](https://github.com/jperasmus/docsify-copy-code/blob/master/README.md) for more details.
+Siehe auch [jperasmus/docsify-copy-code](https://github.com/jperasmus/docsify-copy-code#readme).
 
 ## Disqus
 
-Disqus comments. https://disqus.com/
+[Disqus](https://disqus.com) Kommentare:
 
 ```html
 <script>
@@ -133,7 +133,7 @@ Disqus comments. https://disqus.com/
 
 ## Gitalk
 
-[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact.
+[Gitalk](https://github.com/gitalk/gitalk) basiert auf Github Issue und Preact.
 
 ```html
 <link rel="stylesheet" href="//unpkg.com/gitalk/dist/gitalk.css">
@@ -153,11 +153,27 @@ Disqus comments. https://disqus.com/
 </script>
 ```
 
-## Pagination
+## Seitenumbrüche
 
-Pagination for docsify. By [@imyelo](https://github.com/imyelo)
+Seitenumbrüche, zur Verfügung gestellt von [@imyelo](https://github.com/imyelo):
 
 ```html
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
+```
+
+## codefund
+
+Eine [Erweiterung](https://github.com/njleonzhang/docsify-plugin-codefund) für [codefund.io](https://codefund.io/).
+
+> codefund war vorher codesponsor
+
+```
+<script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+
+window.$docsify = {
+  plugins: [
+    DocsifyCodefund.create('xxxx-xxx-xxx') // change to your codefund id
+  ]
+}
 ```

--- a/docs/de-de/quickstart.md
+++ b/docs/de-de/quickstart.md
@@ -32,7 +32,7 @@ Du kannst einen lokalen Server mit dem Befehl `docsify serve` laufen lassen, und
 docsify serve docs
 ```
 
-?> Für weitere Informationen hinsichtlich der Verwendung von `docsify-cli`, siehe [docsify-cli Dokumentation](https://github.com/QingWei-Li/docsify-cli).
+?> Für weitere Informationen hinsichtlich der Verwendung von `docsify-cli`, siehe [docsify-cli Dokumentation](https://github.com/docsifyjs/docsify-cli).
 
 ## Manuelle Inbetriebnahme
 

--- a/docs/de-de/ssr.md
+++ b/docs/de-de/ssr.md
@@ -1,22 +1,22 @@
 # Server-Side Rendering
 
-See https://docsify.now.sh
+* siehe <https://docsify.now.sh>
+* Quellcode siehe <https://github.com/docsifyjs/docsify-ssr-demo>
 
-Repo in https://github.com/QingWei-Li/docsify-ssr-demo
+## Warum SSR?
 
-## Why SSR?
-- Better SEO
-- Feeling cool
+- Bessere SEO
+- Damit du dich cool fühlst!
 
-## Quick start
+## Schnellstart
 
-Install `now` and `docsify-cli` in your project.
+Installiere `now` und `docsify-cli` in deinem Projekt.
 
 ```bash
 npm i now docsify-cli -D
 ```
 
-Edit `package.json`. If the documentation in `./docs` subdirectory.
+Ändere `package.json`. Im folgenden Beispiel ist die Dokumentation im `./docs` Verzeichnis:
 
 ```json
 {
@@ -30,7 +30,7 @@ Edit `package.json`. If the documentation in `./docs` subdirectory.
   ],
   "docsify": {
     "config": {
-      "basePath": 'https://docsify.js.org/',
+      "basePath": "https://docsify.js.org/",
       "loadSidebar": true,
       "loadNavbar": true,
       "coverpage": true,
@@ -40,9 +40,9 @@ Edit `package.json`. If the documentation in `./docs` subdirectory.
 }
 ```
 
-!> The `basePath` just like webpack `publicPath`. We can use local or remote files.
+!> Für `basePath` ist dies der gleiche wie bei webpack `publicPath`. Unterstützt werden lokale oder remote Dateien.
 
-We can preview in the local to see if it works.
+Wir können lokale Dateien verwenden, um zu sehen, ob es funktioniert.
 
 ```bash
 npm start
@@ -50,17 +50,17 @@ npm start
 # open http://localhost:4000
 ```
 
-Publish it!
+Veröffentliche sie!
 
 ```bash
 now -p
 ```
 
-Now, You have a support for SSR the docs site.
+Damit hast du SSR Unterstützung für deine Dokumentation.
 
-## Custom template
+## Eigene Vorlagen
 
-You can provide a templte for entire page's HTML. such as
+Du kannst eine Vorlage für deine gesammte Seite wie folgt erstellen:
 
 ```html
 <!DOCTYPE html>
@@ -83,13 +83,14 @@ You can provide a templte for entire page's HTML. such as
 </html>
 ```
 
-The template should contain these comments for rendered app content.
+Die Vorlage sollte folgende Kommentare für die Anzeige von Inhalten enthalten:
+
  - `<!--inject-app-->`
  - `<!--inject-config-->`
 
-## Configuration
+## Einstellungen
 
-You can configure it in a special config file, or `package.json`.
+Du kannst die Einstellungen in einer speziellen Datei oder in `package.json` vornehmen:
 
 ```js
 module.exports = {
@@ -100,9 +101,9 @@ module.exports = {
 }
 ```
 
-## Deploy for your VPS
+## Deploy für deinen VPS
 
-You can run `docsify start` directly on your Node server, or write your own server app with `docsify-server-renderer`.
+Führe `docsify start` direkt auf deinem Node Server aus, oder schreibe deine eigene Server app mit `docsify-server-renderer`:
 
 ```js
 var Renderer = require('docsify-server-renderer')
@@ -113,7 +114,7 @@ var renderer = new Renderer({
   template: readFileSync('./docs/index.template.html', 'utf-8').,
   config: {
     name: 'docsify',
-    repo: 'qingwei-li/docsify'
+    repo: 'docsifyjs/docsify'
   }
 })
 

--- a/docs/de-de/themes.md
+++ b/docs/de-de/themes.md
@@ -20,7 +20,7 @@ Es gibt im Moment vier Themes zur Auswahl, ähnlich wie die Webseiten von [Vue](
 <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/pure.css">
 ```
 
-Solltest du weitere Themes erstellen, kannst du sie gerne der Allgemeinheit mit einem [pull request](https://github.com/QingWei-Li/docsify/pulls) zur Verfügung stellen.
+Solltest du weitere Themes erstellen, kannst du sie gerne der Allgemeinheit mit einem [pull request](https://github.com/docsifyjs/docsify/pulls) zur Verfügung stellen.
 
 #### Klicke hier für eine Vorschau
 
@@ -57,6 +57,6 @@ Solltest du weitere Themes erstellen, kannst du sie gerne der Allgemeinheit mit 
 
 
 
-## Other themes
+## Andere themes
 
-- [docsify-themeable](https://jhildenbiddle.github.io/docsify-themeable/#/) A delightfully simple theme system for docsify.
+- [docsify-themeable](https://jhildenbiddle.github.io/docsify-themeable/#/) Ein erfreulicherweise einfaches theme system für docsify.

--- a/docs/de-de/write-a-plugin.md
+++ b/docs/de-de/write-a-plugin.md
@@ -59,7 +59,7 @@ window.$docsify = {
         '<hr/>',
         '<footer>',
         '<span><a href="https://github.com/QingWei-Li">cinwell</a> &copy;2017.</span>',
-        '<span>Proudly published with <a href="https://github.com/QingWei-Li/docsify" target="_blank">docsify</a>.</span>',
+        '<span>Proudly published with <a href="https://github.com/docsifyjs/docsify" target="_blank">docsify</a>.</span>',
         '</footer>'
       ].join('')
 
@@ -79,7 +79,7 @@ window.$docsify = {
   plugins: [
     function(hook, vm) {
       hook.beforeEach(function (html) {
-        var url = 'https://github.com/QingWei-Li/docsify/blob/master/docs' + vm.route.file
+        var url = 'https://github.com/docsifyjs/docsify/blob/master/docs' + vm.route.file
         var editHtml = '[📝 EDIT DOCUMENT](' + url + ')\n'
 
         return editHtml

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,8 +27,8 @@
   <script>
     window.$docsify = {
       alias: {
-        '.*?/awesome': 'https://raw.githubusercontent.com/QingWei-Li/awesome-docsify/master/README.md',
-        '.*?/changelog': 'https://raw.githubusercontent.com/QingWei-Li/docsify/master/CHANGELOG.md',
+        '.*?/awesome': 'https://raw.githubusercontent.com/docsifyjs/awesome-docsify/master/README.md',
+        '.*?/changelog': 'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG.md',
         '/.*/_navbar.md': '/_navbar.md'
       },
       auto2top: true,
@@ -58,7 +58,7 @@
       plugins: [
         function (hook, vm) {
           hook.beforeEach(function (html) {
-            var url = 'https://github.com/QingWei-Li/docsify/blob/master/docs/' + vm.route.file
+            var url = 'https://github.com/docsifyjs/docsify/blob/master/docs/' + vm.route.file
             var editHtml = '[:memo: Edit Document](' + url + ')\n'
 
             return editHtml

--- a/docs/more-pages.md
+++ b/docs/more-pages.md
@@ -25,7 +25,7 @@ docs/zh-cn/guide.md   => http://domain.com/zh-cn/guide
 
 ## Sidebar
 
-In order to have sidebar, then you can create your own `_sidebar.md` (see [this documentation's sidebar](https://github.com/QingWei-Li/docsify/blob/master/docs/_sidebar.md) for an example):
+In order to have sidebar, then you can create your own `_sidebar.md` (see [this documentation's sidebar](https://github.com/docsifyjs/docsify/blob/master/docs/_sidebar.md) for an example):
 
 First, you need to set `loadSidebar` to **true**. Details are available in the [configuration paragraph](configuration.md#loadsidebar).
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -164,7 +164,7 @@ Pagination for docsify. By [@imyelo](https://github.com/imyelo)
 
 ## codefund
 
-a [plugin](https://github.com/njleonzhang/docsify-plugin-codefund) to make it easy to join up [codefund](https://codesponsor.io/)
+a [plugin](https://github.com/njleonzhang/docsify-plugin-codefund) to make it easy to join up [codefund](https://codefund.io/)
 
 > codefund is formerly known as "codesponsor"
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,7 @@ Run the local server with `docsify serve`. You can preview your site in your bro
 docsify serve docs
 ```
 
-?> For more use cases of `docsify-cli`, head over to the [docsify-cli documentation](https://github.com/QingWei-Li/docsify-cli).
+?> For more use cases of `docsify-cli`, head over to the [docsify-cli documentation](https://github.com/docsifyjs/docsify-cli).
 
 ## Manual initialization
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -2,7 +2,7 @@
 
 See https://docsify.now.sh
 
-Repo in https://github.com/QingWei-Li/docsify-ssr-demo
+Repo in https://github.com/docsifyjs/docsify-ssr-demo
 
 ## Why SSR?
 - Better SEO
@@ -114,7 +114,7 @@ var renderer = new Renderer({
   template: readFileSync('./docs/index.template.html', 'utf-8').,
   config: {
     name: 'docsify',
-    repo: 'qingwei-li/docsify'
+    repo: 'docsifyjs/docsify'
   }
 })
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -20,7 +20,7 @@ There are currently three themes available. Copy [Vue](//vuejs.org) and [buble](
 <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/pure.css">
 ```
 
-If you have any ideas or would like to develop a new theme, you are welcome to submit a [pull request](https://github.com/QingWei-Li/docsify/pulls).
+If you have any ideas or would like to develop a new theme, you are welcome to submit a [pull request](https://github.com/docsifyjs/docsify/pulls).
 
 #### Click to preview
 

--- a/docs/write-a-plugin.md
+++ b/docs/write-a-plugin.md
@@ -59,7 +59,7 @@ window.$docsify = {
         '<hr/>',
         '<footer>',
         '<span><a href="https://github.com/QingWei-Li">cinwell</a> &copy;2017.</span>',
-        '<span>Proudly published with <a href="https://github.com/QingWei-Li/docsify" target="_blank">docsify</a>.</span>',
+        '<span>Proudly published with <a href="https://github.com/docsifyjs/docsify" target="_blank">docsify</a>.</span>',
         '</footer>'
       ].join('')
 
@@ -78,7 +78,7 @@ window.$docsify = {
   plugins: [
     function(hook, vm) {
       hook.beforeEach(function (html) {
-        var url = 'https://github.com/QingWei-Li/docsify/blob/master/docs' + vm.route.file
+        var url = 'https://github.com/docsifyjs/docsify/blob/master/docs' + vm.route.file
         var editHtml = '[📝 EDIT DOCUMENT](' + url + ')\n'
 
         return editHtml

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -19,11 +19,11 @@ docsify 是一个动态生成文档网站的工具。不同于 GitBook、Hexo �
 - 丰富的 API
 - 支持 Emoji
 - 兼容 IE10+
-- 支持 SSR ([example](https://github.com/QingWei-Li/docsify-ssr-demo))
+- 支持 SSR ([example](https://github.com/docsifyjs/docsify-ssr-demo))
 
 ## 例子
 
-可以查看 [Showcase](https://github.com/QingWei-Li/docsify/#showcase) 来了解使用 docsify 的文档项目。
+可以查看 [Showcase](https://github.com/docsifyjs/docsify/#showcase) 来了解使用 docsify 的文档项目。
 
 ## 捐赠
 

--- a/docs/zh-cn/configuration.md
+++ b/docs/zh-cn/configuration.md
@@ -5,7 +5,7 @@
 ```html
 <script>
   window.$docsify = {
-    repo: 'QingWei-Li/docsify',
+    repo: 'docsifyjs/docsify',
     maxLevel: 3,
     coverpage: true
   }
@@ -34,9 +34,9 @@ window.$docsify = {
 
 ```js
 window.$docsify = {
-  repo: 'QingWei-Li/docsify',
+  repo: 'docsifyjs/docsify',
   // or
-  repo: 'https://github.com/QingWei-Li/docsify/'
+  repo: 'https://github.com/docsifyjs/docsify/'
 };
 ```
 
@@ -127,7 +127,7 @@ window.$docsify = {
 
   // 文档和仓库根目录下的 README.md 内容一致
   homepage:
-    'https://raw.githubusercontent.com/QingWei-Li/docsify/master/README.md'
+    'https://raw.githubusercontent.com/docsifyjs/docsify/master/README.md'
 };
 ```
 
@@ -268,7 +268,7 @@ window.$docsify = {
     '/foo/(+*)': '/bar/$1', // supports regexp
     '/zh-cn/changelog': '/changelog',
     '/changelog':
-      'https://raw.githubusercontent.com/QingWei-Li/docsify/master/CHANGELOG',
+      'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG',
     '/.*/_sidebar.md': '/_sidebar.md' // See #301
   }
 };
@@ -278,7 +278,7 @@ window.$docsify = {
 
 - 类型：`Boolean`
 
-同时设置 `loadSidebar` 和 `autoHeader` 后，可以根据 `_sidebar.md` 的内容自动为每个页面增加标题。[#78](https://github.com/QingWei-Li/docsify/issues/78)
+同时设置 `loadSidebar` 和 `autoHeader` 后，可以根据 `_sidebar.md` 的内容自动为每个页面增加标题。[#78](https://github.com/docsifyjs/docsify/issues/78)
 
 ```js
 window.$docsify = {
@@ -379,7 +379,7 @@ window.$docsify = {
 
 - 类型: `Array`
 
-有时我们不希望 docsify 处理我们的链接。 参考 [#203](https://github.com/QingWei-Li/docsify/issues/203)
+有时我们不希望 docsify 处理我们的链接。 参考 [#203](https://github.com/docsifyjs/docsify/issues/203)
 
 ```js
 window.$docsify = {

--- a/docs/zh-cn/cover.md
+++ b/docs/zh-cn/cover.md
@@ -30,7 +30,7 @@ _\_coverpage.md_
 * Multiple themes
 * Not build static html files
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Get Started](#quick-start)
 ```
 
@@ -45,7 +45,7 @@ _\_coverpage.md_
 ```markdown
 # docsify
 
-[GitHub](https://github.com/QingWei-Li/docsify/)
+[GitHub](https://github.com/docsifyjs/docsify/)
 [Get Started](#quick-start)
 
 <!-- 背景图片 -->

--- a/docs/zh-cn/quickstart.md
+++ b/docs/zh-cn/quickstart.md
@@ -32,7 +32,7 @@ docsify init ./docs
 docsify serve docs
 ```
 
-?> 更多命令行工具用法，参考 [docsify-cli 文档](https://github.com/QingWei-Li/docsify-cli)。
+?> 更多命令行工具用法，参考 [docsify-cli 文档](https://github.com/docsifyjs/docsify-cli)。
 
 ## 手动初始化
 

--- a/docs/zh-cn/ssr.md
+++ b/docs/zh-cn/ssr.md
@@ -2,7 +2,7 @@
 
 先看例子 https://docsify.now.sh
 
-项目地址在 https://github.com/QingWei-Li/docsify-ssr-demo
+项目地址在 https://github.com/docsifyjs/docsify-ssr-demo
 
 ![](https://dn-mhke0kuv.qbox.me/2bfef08c592706108055.png)
 
@@ -106,7 +106,7 @@ var renderer = new Renderer({
   template: readFileSync('./docs/index.template.html', 'utf-8').,
   config: {
     name: 'docsify',
-    repo: 'qingwei-li/docsify'
+    repo: 'docsifyjs/docsify'
   }
 })
 

--- a/docs/zh-cn/themes.md
+++ b/docs/zh-cn/themes.md
@@ -18,7 +18,7 @@
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/pure.css">
 ```
 
-如果你有其他想法或者想开发别的主题，欢迎提 [PR](https://github.com/QingWei-Li/docsify/pulls)。
+如果你有其他想法或者想开发别的主题，欢迎提 [PR](https://github.com/docsifyjs/docsify/pulls)。
 
 #### 点击切换主题
 

--- a/docs/zh-cn/write-a-plugin.md
+++ b/docs/zh-cn/write-a-plugin.md
@@ -59,7 +59,7 @@ window.$docsify = {
         '<hr/>',
         '<footer>',
         '<span><a href="https://github.com/QingWei-Li">cinwell</a> &copy;2017.</span>',
-        '<span>Proudly published with <a href="https://github.com/QingWei-Li/docsify" target="_blank">docsify</a>.</span>',
+        '<span>Proudly published with <a href="https://github.com/docsifyjs/docsify" target="_blank">docsify</a>.</span>',
         '</footer>'
       ].join('')
 
@@ -79,7 +79,7 @@ window.$docsify = {
   plugins: [
     function(hook, vm) {
       hook.beforeEach(function (html) {
-        var url = 'https://github.com/QingWei-Li/docsify/blob/master/docs' + vm.route.file
+        var url = 'https://github.com/docsifyjs/docsify/blob/master/docs' + vm.route.file
         var editHtml = '[📝 EDIT DOCUMENT](' + url + ')\n'
 
         return editHtml

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <script>
     window.$docsify = {
       alias: {
-        '.*?/changelog': 'https://raw.githubusercontent.com/QingWei-Li/docsify/master/CHANGELOG',
+        '.*?/changelog': 'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG',
         '/.*/_navbar.md': '/_navbar.md'
       },
       notFoundPage: '_404.html',
@@ -38,7 +38,7 @@
       plugins: [
         function (hook, vm) {
           hook.beforeEach(function (html) {
-            var url = 'https://github.com/QingWei-Li/docsify/blob/master/' + vm.route.file
+            var url = 'https://github.com/docsifyjs/docsify/blob/master/' + vm.route.file
             var editHtml = '[:memo: Edit Document](' + url + ')\n'
 
             return editHtml

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/QingWei-Li/docsify.git"
+    "url": "git+https://github.com/docsifyjs/docsify.git"
   },
   "main": "lib/docsify.js",
   "unpkg": "lib/docsify.min.js",

--- a/packages/docsify-server-renderer/README.md
+++ b/packages/docsify-server-renderer/README.md
@@ -17,7 +17,7 @@ var renderer = new Renderer({
   template: readFileSync('./docs/index.template.html', 'utf-8').,
   config: {
     name: 'docsify',
-    repo: 'qingwei-li/docsify'
+    repo: 'docsifyjs/docsify'
   }
 })
 

--- a/packages/docsify-server-renderer/package.json
+++ b/packages/docsify-server-renderer/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://docsify.js.org",
   "license": "MIT",
-  "repository": "QingWei-Li/docsify",
+  "repository": "docsifyjs/docsify",
   "main": "build.js",
   "scripts": {
     "test": "echo 'hello'"

--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ if (isSSR) {
   </html>`,
     config: {
       name: 'docsify',
-      repo: 'qingwei-li/docsify',
+      repo: 'docsifyjs/docsify',
       basePath: 'https://docsify.js.org/',
       loadNavbar: true,
       loadSidebar: true,
@@ -32,7 +32,7 @@ if (isSSR) {
         '/de-de/changelog': '/changelog',
         '/zh-cn/changelog': '/changelog',
         '/changelog':
-          'https://raw.githubusercontent.com/QingWei-Li/docsify/master/CHANGELOG'
+          'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG'
       }
     },
     path: './'


### PR DESCRIPTION
* updated german links
* fixed links where `QingWei-Li` should've been `docsifyjs`
  * naturally excluded donate links and links to private projects like `vuep` unrelated to docsify

---

See commit for details. If you have a question, just ask.