### PR TITLE
Update vue.styl (issue #635)

### DIFF
--- a/src/themes/vue.styl
+++ b/src/themes/vue.styl
@@ -159,7 +159,7 @@ body
 .token.attr-value, .token.control, .token.directive, .token.unit
   color var(--theme-color, $color-primary)
 
-.token.keyword
+.token.keyword, .token.function
   color #e96900
 
 .token.statement, .token.regex, .token.atrule


### PR DESCRIPTION
CSS style for functions is specified in buble.styl only. Thus, for example, bash commands from prism-bash.js (function section) are not highlighted. You can add a new CSS style with the right color you think fits better  :).

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [X] DO NOT include files inside `lib` directory.
