### PR TITLE
Remove target for mailto links

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -213,7 +213,7 @@ export class Compiler {
         }
         href = router.toURL(href, null, router.getCurrentPath())
       } else {
-        attrs += ` target="${linkTarget}"`
+        attrs += href.startsWith('mailto:') ? '' : ` target="${linkTarget}"`
       }
 
       if (config.target) {


### PR DESCRIPTION
Closes https://github.com/docsifyjs/docsify/issues/625

Note: Not covering https://github.com/docsifyjs/docsify/blob/master/src/core/render/compiler.js#L219-L221 because there shouldn't be a case where you would attach`target` config to a `mailto` link.
