### PR TITLE
fix: unexpected 404

### DIFF
--- a/src/core/render/embed.js
+++ b/src/core/render/embed.js
@@ -57,9 +57,11 @@ function walkFetchEmbed({embedTokens, compile, fetch}, cb) {
 }
 
 export function prerenderEmbed({compiler, raw = '', fetch}, done) {
-  let hit
-  if ((hit = cached[raw])) {
-    return done(hit)
+  let hit = cached[raw]
+  if (hit) {
+    const copy = hit.slice()
+    copy.links = hit.links
+    return done(copy)
   }
 
   const compile = compiler._marked


### PR DESCRIPTION
Closes https://github.com/docsifyjs/docsify/issues/664

### Issue

`prerenderEmbed` is using the actual cached value when there is a hit. The value (an array) gets cleared somehow during processing https://github.com/docsifyjs/docsify/blob/master/src/core/render/index.js#L159. By the time the cached value is hit again, though the value is not `undefined`, the content is empty. Hence 404 shows up.

### Solution

Using a copy of cached value solves the problem.

-----

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
