### PR TITLE
fix: customising cover page background colour not working

### DIFF
--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -176,9 +176,10 @@ export function renderMixin(proto) {
     dom.toggleClass(el, 'add', 'show')
 
     let html = this.coverIsHTML ? text : this.compiler.cover(text)
+
     const m = html
       .trim()
-      .match('<p><img.*?data-origin="(.*?)"[^a]+alt="(.*?)">([^<]*?)</p>$')
+      .match('<img.*?data-origin="(.*?)"[^a]+alt="(.*?)">([^<]*?)$')
 
     if (m) {
       if (m[2] === 'color') {


### PR DESCRIPTION
Closes https://github.com/docsifyjs/docsify/issues/666

### Issue

`marked@0.5.1` renders image without `<p>` wrapper, which is different from `marked@0.3.12`.

### Solution

Updating match regex in `_renderCover` solves the problem.

-----

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
