### PR TITLE
[WIP] fix: cover page button style

### DIFF
--- a/src/themes/basic/_coverpage.styl
+++ b/src/themes/basic/_coverpage.styl
@@ -61,7 +61,7 @@ section.cover
     max-width 500px
     padding 0
 
-  .cover-main > p:last-child a
+  .cover-main > a
     border-color var(--theme-color, $color-primary)
     border-radius 2rem
     border-style solid


### PR DESCRIPTION
Closes https://github.com/docsifyjs/docsify/issues/665

### Issue

CSS selector for cover page buttons are not working due to change of `marked` output. No `<p>` wrapper anymore.

### Solution

Update CSS selector solves the problem.

### Discussion

Although updating CSS selector solves the problem, it brings a potential issue: all direct child `<a>` tags of `.cover-main` will now be rendered as a "cover page button".

Another way of solving this might be adding a new wrapper to buttons, or add configs (`[GitHub](https://github.com/docsify :cover-page-button)`) to links to declare that they should be styled as "cover page buttons".

@QingWei-Li what's your opinion?

-----

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
