### PR TITLE
feat(search-plugin): add namespace option

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,6 +40,10 @@ By default, the hyperlink on the current page is recognized and the content is s
       depth: 2,
 
       hideOtherSidebarContent: false, // whether or not to hide other sidebar content
+
+      // To avoid search index collision
+      // between multiple websites under the same domain
+      namespace: 'website-1',
     }
   }
 </script>

--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -7,7 +7,8 @@ const CONFIG = {
   paths: 'auto',
   depth: 2,
   maxAge: 86400000, // 1 day
-  hideOtherSidebarContent: false
+  hideOtherSidebarContent: false,
+  namespace: undefined
 }
 
 const install = function (hook, vm) {
@@ -23,6 +24,7 @@ const install = function (hook, vm) {
     CONFIG.noData = opts.noData || CONFIG.noData
     CONFIG.depth = opts.depth || CONFIG.depth
     CONFIG.hideOtherSidebarContent = opts.hideOtherSidebarContent || CONFIG.hideOtherSidebarContent
+    CONFIG.namespace = opts.namespace || CONFIG.namespace
   }
 
   const isAuto = CONFIG.paths === 'auto'


### PR DESCRIPTION
### Issue

Local storage stores data per domain. [[1]](https://stackoverflow.com/a/4201249)

> It's unique per `protocol://host:port` combination.

Take the example in https://github.com/docsifyjs/docsify/issues/697:

- https://ramblerw.github.io/blog-money
- https://ramblerw.github.io/python3

They are under the same domain `https://ramblerw.github.io`. Thus, they share the same search index data.

### This PR

Introduces a new option: `namespace`, to avoid local storage collision.

If `namespace` is set, search index data will be saved under a namespaced key, e.g. `docsify.search.index/docsify-test-namespace`.

Fixes https://github.com/docsifyjs/docsify/issues/697


-----

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
