### PR TITLE
Fix getAndRemoveConfig regex

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -19,7 +19,7 @@ export function getAndRemoveConfig(str = '') {
     str = str
       .replace(/^'/, '')
       .replace(/'$/, '')
-      .replace(/\s:([\w-]+)=?([\w-]+)?/g, (m, key, value) => {
+      .replace(/(?:^|\s):([\w-]+)=?([\w-]+)?/g, (m, key, value) => {
         config[key] = (value && value.replace(/&quot;/g, '')) || true
         return ''
       })

--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -19,7 +19,7 @@ export function getAndRemoveConfig(str = '') {
     str = str
       .replace(/^'/, '')
       .replace(/'$/, '')
-      .replace(/:([\w-]+)=?([\w-]+)?/g, (m, key, value) => {
+      .replace(/:([\w-]+)=?([\w-]+)?(?=\s)/g, (m, key, value) => {
         config[key] = (value && value.replace(/&quot;/g, '')) || true
         return ''
       })

--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -19,7 +19,7 @@ export function getAndRemoveConfig(str = '') {
     str = str
       .replace(/^'/, '')
       .replace(/'$/, '')
-      .replace(/:([\w-]+)=?([\w-]+)?(?=\s)/g, (m, key, value) => {
+      .replace(/\s:([\w-]+)=?([\w-]+)?/g, (m, key, value) => {
         config[key] = (value && value.replace(/&quot;/g, '')) || true
         return ''
       })


### PR DESCRIPTION
Update getAndRemoveConfig regular expression for prevent cases, when header has name like `# foo::bar::baz`. 
We use docsify for perl, our regular case: `### Some::Module`, and without fixed regex we have header like `### Some:`.

Compatible with FireFox.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
