### PR TITLE
feat: allows relative path, fixed #590

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,46 @@ window.$docsify = {
 };
 ```
 
+## relativePath
+
+- Type: `Boolean`
+- Default: `false`
+
+If **true** links are relative to the current context.
+
+For example, the directory structure is as follows:
+
+```text
+.
+└── docs
+    ├── README.md
+    ├── guide.md
+    └── zh-cn
+        ├── README.md
+        ├── guide.md
+        └── config
+            └── example.md
+```
+
+With relative path **enabled** and current URL `http://domain.com/zh-cn/README`, given links will resolve to:
+
+```text
+guide.md              => http://domain.com/zh-cn/guide
+config/example.md     => http://domain.com/zh-cn/config/example
+../README.md          => http://domain.com/README
+/README.md            => http://domain.com/README
+```
+
+```js
+window.$docsify = {
+  // Relative path enabled
+  relativePath: true,
+
+  // Relative path disabled (default value)
+  relativePath: false
+};
+```
+
 ## coverpage
 
 - Type: `Boolean|String|String[]|Object`

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -25,7 +25,8 @@ export default function () {
       formatUpdated: '',
       externalLinkTarget: '_blank',
       routerMode: 'hash',
-      noCompileLinks: []
+      noCompileLinks: [],
+      relativePath: false
     },
     window.$docsify
   )

--- a/src/core/router/history/base.js
+++ b/src/core/router/history/base.js
@@ -74,11 +74,11 @@ export class History {
     if (local) {
       const idIndex = currentRoute.indexOf('?')
       path =
-        (idIndex > 0 ? currentRoute.substr(0, idIndex) : currentRoute) + path
+        (idIndex > 0 ? currentRoute.substring(0, idIndex) : currentRoute) + path
     }
 
-    if (this.config.relativePath && !path.startsWith('/')) {
-      const currentDir = currentRoute.substr(0, currentRoute.lastIndexOf('/') + 1)
+    if (this.config.relativePath && path.indexOf('/') !== 0) {
+      const currentDir = currentRoute.substring(0, currentRoute.lastIndexOf('/') + 1)
       return cleanPath(resolvePath(currentDir + path))
     }
     return cleanPath('/' + path)

--- a/src/core/router/history/base.js
+++ b/src/core/router/history/base.js
@@ -3,7 +3,8 @@ import {
   isAbsolutePath,
   stringifyQuery,
   cleanPath,
-  replaceSlug
+  replaceSlug,
+  resolvePath
 } from '../util'
 import {noop, merge} from '../../util/core'
 
@@ -76,6 +77,10 @@ export class History {
         (idIndex > 0 ? currentRoute.substr(0, idIndex) : currentRoute) + path
     }
 
+    if (this.config.relativePath && !path.startsWith('/')) {
+      const currentDir = currentRoute.substr(0, currentRoute.lastIndexOf('/') + 1)
+      return cleanPath(resolvePath(currentDir + path))
+    }
     return cleanPath('/' + path)
   }
 }

--- a/src/core/router/util.js
+++ b/src/core/router/util.js
@@ -53,6 +53,20 @@ export const cleanPath = cached(path => {
   return path.replace(/^\/+/, '/').replace(/([^:])\/{2,}/g, '$1/')
 })
 
+export const resolvePath = cached(path => {
+  const segments = path.replace(/^\//, '').split('/')
+  let resolved = []
+  for (let i = 0, len = segments.length; i < len; i++) {
+    const segment = segments[i]
+    if (segment === '..') {
+      resolved.pop()
+    } else if (segment !== '.') {
+      resolved.push(segment)
+    }
+  }
+  return '/' + resolved.join('/')
+})
+
 export function getPath(...args) {
   return cleanPath(args.join('/'))
 }

--- a/test/unit/base.js
+++ b/test/unit/base.js
@@ -1,0 +1,62 @@
+/* eslint-env node, chai, mocha */
+require = require('esm')(module/*, options*/)
+const {expect} = require('chai')
+const {History} = require('../../src/core/router/history/base')
+
+class MockHistory extends History {
+  parse(path) {
+    return {path}
+  }
+}
+
+describe('router/history/base', function () {
+  describe('relativePath true', function () {
+    var history
+
+    beforeEach(function () {
+      history = new MockHistory({relativePath: true})
+    })
+
+    it('toURL', function () {
+      // WHEN
+      const url = history.toURL('guide.md', {}, '/zh-ch/')
+
+      // THEN
+      expect(url).equal('/zh-ch/guide')
+    })
+
+    it('toURL with double dot', function () {
+      // WHEN
+      const url = history.toURL('../README.md', {}, '/zh-ch/')
+
+      // THEN
+      expect(url).equal('/README')
+    })
+
+    it('toURL child path', function () {
+      // WHEN
+      const url = history.toURL('config/example.md', {}, '/zh-ch/')
+
+      // THEN
+      expect(url).equal('/zh-ch/config/example')
+    })
+
+    it('toURL absolute path', function () {
+      // WHEN
+      const url = history.toURL('/README', {}, '/zh-ch/')
+
+      // THEN
+      expect(url).equal('/README')
+    })
+  })
+
+  it('toURL without relative path', function () {
+    const history = new MockHistory({relativePath: false})
+
+    // WHEN
+    const url = history.toURL('README', {}, '/zh-ch/')
+
+    // THEN
+    expect(url).equal('/README')
+  })
+})

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -1,0 +1,30 @@
+/* eslint-env node, chai, mocha */
+require = require('esm')(module/*, options*/)
+const {expect} = require('chai')
+const {resolvePath} = require('../../src/core/router/util')
+
+describe('router/util', function () {
+  it('resolvePath', async function () {
+    // WHEN
+    const result = resolvePath('hello.md')
+
+    // THEN
+    expect(result).equal('/hello.md')
+  })
+
+  it('resolvePath with dot', async function () {
+    // WHEN
+    const result = resolvePath('./hello.md')
+
+    // THEN
+    expect(result).equal('/hello.md')
+  })
+
+  it('resolvePath with two dots', async function () {
+    // WHEN
+    const result = resolvePath('test/../hello.md')
+
+    // THEN
+    expect(result).equal('/hello.md')
+  })
+})


### PR DESCRIPTION
Hello,

It's the same PR as https://github.com/docsifyjs/docsify/pull/593 thanks to @NoClin which allows relative path (fix #590). But I've added an option relativePath to enable it (like proposed in #657). By default it's disabled so it's backward compatible: no breaking changes. :)

I've tried to add some documentation, I hope it's clear enough.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you are merging your commits to `master` branch.
* [X] Add some descriptions and refer relative issues for you PR.
* [X] DO NOT include files inside `lib` directory.
