### PR TITLE
add prev-next plugin as per #475

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -60,7 +60,8 @@ const buildAllPlugin = function () {
     {name: 'front-matter', input: 'front-matter/index.js'},
     {name: 'zoom-image', input: 'zoom-image.js'},
     {name: 'disqus', input: 'disqus.js'},
-    {name: 'gitalk', input: 'gitalk.js'}
+    {name: 'gitalk', input: 'gitalk.js'},
+    {name: 'prev-next', input: 'prev-next.js'},
   ]
 
   plugins.forEach(item => {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -159,6 +159,19 @@ Disqus comments. https://disqus.com/
 </script>
 ```
 
+## Prev-Next
+
+Pagination for docsify. By [@davestewart](https://github.com/davestewart).
+
+Previous and Next page navigation as titles (harvested from the sidebar) and is navigable by keyboard left / right arrows.
+
+```html
+<script src="//unpkg.com/docsify/lib/plugins/prev-next.min.js"></script>
+```
+
+For a live example, see [Vuex Pathify Docs](https://davestewart.github.io/vuex-pathify/#/?id=home).
+
+
 ## Pagination
 
 Pagination for docsify. By [@imyelo](https://github.com/imyelo)
@@ -174,7 +187,7 @@ a [plugin](https://github.com/njleonzhang/docsify-plugin-codefund) to make it ea
 
 > codefund is formerly known as "codesponsor"
 
-```
+```js
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 
 window.$docsify = {

--- a/src/plugins/prev-next.js
+++ b/src/plugins/prev-next.js
@@ -1,0 +1,74 @@
+function getLink(link) {
+  if (link instanceof Element) {
+    link = link.getAttribute('href')
+  }
+  var hash = (link.match(/#.+/) || '').toString().replace('#', '').replace(/\?.*/, '')
+  return hash || '/'
+}
+
+function getLinks() {
+  var sidebar = document.querySelector('.sidebar')
+  var links = [].slice.call(sidebar.querySelectorAll('a'))
+  var current = links.find(link => getLink(link) === getLink(location.href))
+  var index = links.indexOf(current)
+
+  return {
+    length: links.length,
+    current: current,
+    index: index,
+    prev: links[index - 1],
+    next: links[index + 1]
+  }
+}
+
+function pageNav(hook) {
+  function navigate(name) {
+    var links = getLinks()
+    var link = links[name]
+    if (link) {
+      window.location.hash = getLink(link)
+    }
+  }
+
+  hook.init(function () {
+    window.addEventListener('keydown', function (event) {
+      if (!event.ctrlKey && !event.metaKey) {
+        if (event.keyCode === 37) {
+          navigate('prev')
+        }
+        if (event.keyCode === 39) {
+          navigate('next')
+        }
+      }
+    })
+  })
+}
+
+function pageLinks(hook) {
+  function makeLinks() {
+    var links = getLinks()
+    if (!links.current) {
+      return ''
+    }
+
+    var html = ''
+    if (links.prev) {
+      html += '<span class="guide-link-prev">' + links.prev.outerHTML + '</span>'
+    }
+    if (links.next) {
+      html += '<span class="guide-link-next">' + links.next.outerHTML + '</span>'
+    }
+
+    return html
+  }
+
+  hook.afterEach(function (html, next) {
+    next(html + '<div class="guide-links">' + makeLinks() + '</div>')
+  })
+
+  hook.ready(function () {
+    document.querySelector('.guide-links').innerHTML = makeLinks()
+  })
+}
+
+$docsify.plugins = [].concat(pageLinks, pageNav, $docsify.plugins)


### PR DESCRIPTION
I saw #475 and thought I would get that done since it has a number of :+1:s

Add prev/next links at the footer of pages based on the sidebar. Supports left/right arrow keyboard navigation.

Feel free to close if an external plugin is more appropriate.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
