### PR TITLE
feat(scroll): smarter scroll behavior

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -1,11 +1,26 @@
 import { isMobile } from '../util/env';
 import { body, on } from '../util/dom';
 import * as sidebar from './sidebar';
-import { scrollIntoView } from './scroll';
+import { scrollIntoView, scroll2Top } from './scroll';
 
 export function eventMixin(proto) {
-  proto.$resetEvents = function() {
-    scrollIntoView(this.route.path, this.route.query.id);
+  proto.$resetEvents = function(source) {
+    const { auto2top } = this.config;
+
+    (() => {
+      // Rely on the browser's scroll auto-restoration when going back or forward
+      if (source === 'history') {
+        return;
+      }
+      // Scroll to ID if specified
+      if (this.route.query.id) {
+        scrollIntoView(this.route.path, this.route.query.id);
+      }
+      // Scroll to top if a link was clicked and auto2top is enabled
+      if (source === 'navigate') {
+        auto2top && scroll2Top(auto2top);
+      }
+    })();
 
     if (this.config.loadNavbar) {
       sidebar.getAndActive(this.router, 'nav');

--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -148,7 +148,10 @@ export function fetchMixin(proto) {
     }
   };
 
-  proto.$fetch = function(cb = noop) {
+  proto.$fetch = function(
+    cb = noop,
+    $resetEvents = this.$resetEvents.bind(this)
+  ) {
     const done = () => {
       callHook(this, 'doneEach');
       cb();
@@ -160,7 +163,7 @@ export function fetchMixin(proto) {
       done();
     } else {
       this._fetch(() => {
-        this.$resetEvents();
+        $resetEvents();
         done();
       });
     }

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -6,7 +6,7 @@ import { getAndActive, sticky } from '../event/sidebar';
 import { getPath, isAbsolutePath } from '../router/util';
 import { isMobile, inBrowser } from '../util/env';
 import { isPrimitive } from '../util/core';
-import { scrollActiveSidebar, scroll2Top } from '../event/scroll';
+import { scrollActiveSidebar } from '../event/scroll';
 import { Compiler } from './compiler';
 import * as tpl from './tpl';
 import { prerenderEmbed } from './embed';
@@ -123,7 +123,7 @@ export function renderMixin(proto) {
   };
 
   proto._bindEventOnRendered = function(activeEl) {
-    const { autoHeader, auto2top } = this.config;
+    const { autoHeader } = this.config;
 
     scrollActiveSidebar(this.router);
 
@@ -136,8 +136,6 @@ export function renderMixin(proto) {
         dom.before(main, wrapper.children[0]);
       }
     }
-
-    auto2top && scroll2Top(auto2top);
   };
 
   proto._renderNav = function(text) {

--- a/src/core/router/history/hash.js
+++ b/src/core/router/history/hash.js
@@ -30,7 +30,25 @@ export class HashHistory extends History {
   }
 
   onchange(cb = noop) {
-    on('hashchange', cb);
+    // The hashchange event does not tell us if it originated from
+    // a clicked link or by moving back/forward in the history;
+    // therefore we set a `navigating` flag when a link is clicked
+    // to be able to tell these two scenarios apart
+    let navigating = false;
+
+    on('click', e => {
+      const el = e.target.tagName === 'A' ? e.target : e.target.parentNode;
+
+      if (el.tagName === 'A' && !/_blank/.test(el.target)) {
+        navigating = true;
+      }
+    });
+
+    on('hashchange', e => {
+      const source = navigating ? 'navigate' : 'history';
+      navigating = false;
+      cb({ event: e, source });
+    });
   }
 
   normalize() {

--- a/src/core/router/history/html5.js
+++ b/src/core/router/history/html5.js
@@ -28,11 +28,13 @@ export class HTML5History extends History {
         e.preventDefault();
         const url = el.href;
         window.history.pushState({ key: url }, '', url);
-        cb();
+        cb({ event: e, source: 'navigate' });
       }
     });
 
-    on('popstate', cb);
+    on('popstate', e => {
+      cb({ event: e, source: 'history' });
+    });
   }
 
   /**

--- a/src/core/router/index.js
+++ b/src/core/router/index.js
@@ -2,6 +2,7 @@ import { supportsPushState } from '../util/env';
 import * as dom from '../util/dom';
 import { HashHistory } from './history/hash';
 import { HTML5History } from './history/html5';
+import { noop } from '../util/core';
 
 export function routerMixin(proto) {
   proto.route = {};
@@ -31,16 +32,16 @@ export function initRouter(vm) {
   lastRoute = vm.route;
 
   // eslint-disable-next-line no-unused-vars
-  router.onchange(_ => {
+  router.onchange(params => {
     updateRender(vm);
     vm._updateRender();
 
     if (lastRoute.path === vm.route.path) {
-      vm.$resetEvents();
+      vm.$resetEvents(params.source);
       return;
     }
 
-    vm.$fetch();
+    vm.$fetch(noop, vm.$resetEvents.bind(vm, params.source));
     lastRoute = vm.route;
   });
 }


### PR DESCRIPTION
Currently Docsify has the following behavior when it comes to scrolling:

* if `auto2top` is **enabled** then:
  - _any_ change to a URL that includes an ID will scroll to that ID once loaded
  - _any_ change to a URL without an ID always scrolls to the top once loaded
  - therefore the browser's scroll restoration behavior is always nullified when moving back/forward in history or reloading the page
* if `auto2top` is **disabled** then:
  - _any_ change to a URL that includes an ID will scroll to that ID once loaded
  - moving back/forward in history and reloading the page uses the browser's scroll restoration behavior, but only if the target does not have an ID
  - clicking a link to navigate to a page that does not include an ID maintains the current scroll position and usually ends up somewhere in the middle of that page (fixes https://github.com/docsifyjs/docsify-cli/issues/42; fixes https://github.com/docsifyjs/docsify/issues/612)

Ideally, the following should happen (in my opinion):

* moving back/forward in history and reloading the current page should not invoke any kind of scrolling behavior and therefore should _not_ override the browser's scroll restoration behavior
* clicking a link to navigate to a page should scroll to the top of that page or to an ID if specified

This PR implements this (in my opinion better) behavior for both the `hash` and the `history` router modes. Scrolling to the top only happens if `auto2top` is enabled.

It does _not_ attempt to fix the inconsistent scrolling issue that's caused by images loaded asynchronously.

* [X] Make sure you are merging your commits to `master` branch.
* [X] Add some descriptions and refer relative issues for you PR.
* [X] DO NOT include files inside `lib` directory.
