### PR TITLE
fix(emoji): fix github url

### DIFF
--- a/src/plugins/emoji.js
+++ b/src/plugins/emoji.js
@@ -892,7 +892,7 @@ const AllGithubEmoji = [
 window.emojify = function (match, $1) {
   return AllGithubEmoji.indexOf($1) === -1 ?
     match :
-    '<img class="emoji" src="https://assets-cdn.github.com/images/icons/emoji/' +
+    '<img class="emoji" src="https://github.com/images/icons/emoji/' +
       $1 +
       '.png" alt="' +
       $1 +


### PR DESCRIPTION
Closes issue https://github.com/docsifyjs/docsify/issues/768

In summary: https://`assets-cdn.`github.com is not longer available. The new URL for emoji is:  https://github.com/images/icons/emoji/
