### PR TITLE
Added filtering in sidebar for ignoreSubHeading

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -337,7 +337,15 @@ export class Compiler {
       html = this.compile(text)
     } else {
       for (let i = 0; i < toc.length; i++) {
-        toc[i].ignoreSubHeading && toc.splice(i, 1) && i--
+        if (toc[i].ignoreSubHeading) {
+          const deletedHeaderLevel = toc[i].level
+          toc.splice(i, 1)
+          // Remove headers who are under current header
+          for (let j = i; deletedHeaderLevel < toc[j].level && j < toc.length; j++) {
+            toc.splice(j, 1) && j-- && i++
+          }
+          i--
+        }
       }
       const tree = this.cacheTree[currentPath] || genTree(toc, level)
       html = treeTpl(tree, '<ul>{inner}</ul>')

--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -329,13 +329,17 @@ export class Compiler {
    * Compile sidebar
    */
   sidebar(text, level) {
+    const {toc} = this
     const currentPath = this.router.getCurrentPath()
     let html = ''
 
     if (text) {
       html = this.compile(text)
     } else {
-      const tree = this.cacheTree[currentPath] || genTree(this.toc, level)
+      for (let i = 0; i < toc.length; i++) {
+        toc[i].ignoreSubHeading && toc.splice(i, 1) && i--
+      }
+      const tree = this.cacheTree[currentPath] || genTree(toc, level)
       html = treeTpl(tree, '<ul>{inner}</ul>')
       this.cacheTree[currentPath] = tree
     }
@@ -360,7 +364,6 @@ export class Compiler {
     for (let i = 0; i < toc.length; i++) {
       toc[i].ignoreSubHeading && toc.splice(i, 1) && i--
     }
-
     const tree = cacheTree[currentPath] || genTree(toc, level)
 
     cacheTree[currentPath] = tree


### PR DESCRIPTION
Add support for `ignoreSubHeading` when `loadSidebar` is false.

### The issue

When `{docsify-ignore}` is applied on a heading, the generated sidebar still contains the header and its subheaders. When `loadSidebar` is false only the `sidebar()` method is called so the filtering needs to be inserted there. 
https://github.com/docsifyjs/docsify/blob/8cd786c9d533faa15b989f84f7ecf0d8f705a7c8/src/core/render/index.js#L93-L107
I used classic splice() method and for loops to remove the header and all it's subheaders because I saw this method being used `subSidebar()`. I was probably better to just use the `[].filter()` way but it works anyways.

---

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
