### PR TITLE
Fixed iframe overflow bug for mobile Safari

### DIFF
--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -323,6 +323,7 @@ body.sticky
 
 .markdown-section iframe
   border 1px solid #eee
+  /* fix horizontal overflow on iOS Safari */
   width 1px
   min-width 100%
 

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -323,6 +323,8 @@ body.sticky
 
 .markdown-section iframe
   border 1px solid #eee
+  width 1px
+  min-width 100%
 
 .markdown-section table
   border-collapse collapse


### PR DESCRIPTION
On mobile Safari, 100% width iframes can have horizontal overflow from their parent container. This modification to the base theme fixes it.

Fixes #781