### PR TITLE
Fix typo in edit button example

### DIFF
--- a/docs/write-a-plugin.md
+++ b/docs/write-a-plugin.md
@@ -79,7 +79,7 @@ window.$docsify = {
     function(hook, vm) {
       hook.beforeEach(function(html) {
         var url =
-          'https://github.com/docsifyjs/docsify/blob/master/docs' +
+          'https://github.com/docsifyjs/docsify/blob/master/docs/' +
           vm.route.file;
         var editHtml = '[📝 EDIT DOCUMENT](' + url + ')\n';
 


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.

----

### Fix a typo

Missing trailing slash in the `Edit button` url
Result in:

```diff
- https://github.com/docsifyjs/docsify/blob/master/docsREADME.md
+ https://github.com/docsifyjs/docsify/blob/master/docs/README.md
```

