### PR TITLE
Ensure autoHeader dom result is similar to parsed H1

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -82,6 +82,7 @@ export class Compiler {
     this.contentBase = router.getBasePath()
 
     const renderer = this._initRenderer()
+    this.heading = renderer.heading
     let compile
     const mdConf = config.markdown || {}
 
@@ -379,6 +380,10 @@ export class Compiler {
     cacheTree[currentPath] = tree
     this.toc = []
     return treeTpl(tree)
+  }
+
+  header(text, level) {
+    return this.heading(text, level)
   }
 
   article(text) {

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -115,9 +115,9 @@ export function renderMixin(proto) {
       const main = dom.getNode('#main')
       const firstNode = main.children[0]
       if (firstNode && firstNode.tagName !== 'H1') {
-        const h1 = dom.create('h1')
-        h1.innerText = activeEl.innerText
-        dom.before(main, h1)
+        const h1 = this.compiler.header(activeEl.innerText, 1)
+        const wrapper = dom.create('div', h1)
+        dom.before(main, wrapper.children[0])
       }
     }
 


### PR DESCRIPTION
fix https://github.com/docsifyjs/docsify/issues/516

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.

----

In reference to #516 
Ensure the `h1` dom element created by the `autoHeader` feature is similar to the `ħ1` parsed from a markdown file.

```diff
-<h1>Title</h1>
+<h1 id="title">
+  <a href="#/?id=title" data-id="title" class="anchor">
+    <span>Title</span>
+  </a>
+</h1>
```

Please review this code carefully as I don't know if exposing the `renderer` is a good idea.