### PR TITLE
fix config initialization and coercion

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -53,26 +53,22 @@ export default function () {
         }
       }
     }
+  }
 
-    if (config.loadSidebar === true) {
-      config.loadSidebar = '_sidebar' + config.ext
-    }
-
-    if (config.loadNavbar === true) {
-      config.loadNavbar = '_navbar' + config.ext
-    }
-
-    if (config.coverpage === true) {
-      config.coverpage = '_coverpage' + config.ext
-    }
-
-    if (config.repo === true) {
-      config.repo = ''
-    }
-
-    if (config.name === true) {
-      config.name = ''
-    }
+  if (config.loadSidebar === true) {
+    config.loadSidebar = '_sidebar' + config.ext
+  }
+  if (config.loadNavbar === true) {
+    config.loadNavbar = '_navbar' + config.ext
+  }
+  if (config.coverpage === true) {
+    config.coverpage = '_coverpage' + config.ext
+  }
+  if (config.repo === true) {
+    config.repo = ''
+  }
+  if (config.name === true) {
+    config.name = ''
   }
 
   window.$docsify = config

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,5 +1,7 @@
 import {merge, hyphenate, isPrimitive, hasOwn} from './util/core'
 
+const currentScript = document.currentScript
+
 export default function () {
   const config = merge(
     {
@@ -36,7 +38,7 @@ export default function () {
   )
 
   const script =
-    document.currentScript ||
+    currentScript ||
     [].slice
       .call(document.getElementsByTagName('script'))
       .filter(n => /docsify\./.test(n.src))[0]


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

close #860 

This PR fix two problems.

1. `document.currentScript` doesn't work in a callback or event handler, and will always return `null` with initializing config after `DOMContentLoaded` in docsify.

> It's important to note that this will not reference the <script> element if the code in the script is being called as a callback or event handler; it will only reference the element while it's initially being processed. - [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)

https://github.com/docsifyjs/docsify/blob/676f84cffa9d713fbad662371870d7db2109a9b3/src/core/index.js#L38-L41

2. There are some config fields coercions(e.g. `config.loadSidebar === true`) after merging from current executing script, but I think these coercions should not depend on the existence of current script, so I move them out.

https://github.com/docsifyjs/docsify/blob/676f84cffa9d713fbad662371870d7db2109a9b3/src/core/config.js#L34-L66

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome, Chrome/74.0.3729.169
- [ ] Firefox
- [x] Safari, Safari/605.1.15
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [x] DO NOT include files inside `lib` directory.

@timaschew @QingWei-Li 
