### PR TITLE
buble theme: fix strong font-weight increased to 600 (onto master branch)

### DIFF
--- a/src/themes/buble.styl
+++ b/src/themes/buble.styl
@@ -35,9 +35,12 @@ $sidebar-width = 16rem
   color #333
   font-weight 400
 
+.markdown-section strong
+  color #333
+  font-weight 600
+
 .markdown-section a
   color var(--theme-color, $color-primary)
-  font-weight 400
 
 .markdown-section p, .markdown-section ul, .markdown-section ol
   line-height 1.6rem


### PR DESCRIPTION
See #913 for the debate. TLDR:

 I've separated strong and set it to 600. I've removed the `a { font-weight: 400}`, because it has overridden the headings h1, ... font-weight below.

(Links has blue color in the buble theme, so they do not need the slight font-weight increase. I also do not know how to keep font-weight and do not override headings, because headings are links to. I aware of CSS !important, but I think this solution is better for this situation.)