### PR TITLE
fix: allow link targets to override externalLinkTarget

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -227,7 +227,7 @@ export class Compiler {
       return `<pre v-pre data-lang="${lang}"><code class="lang-${lang}">${hl}</code></pre>`
     }
     origin.link = renderer.link = function (href, title = '', text) {
-      let attrs = ''
+      const attrs = {}
 
       const {str, config} = getAndRemoveConfig(title)
       title = str
@@ -241,24 +241,32 @@ export class Compiler {
           href = 'README'
         }
         href = router.toURL(href, null, router.getCurrentPath())
-      } else {
-        attrs += href.indexOf('mailto:') === 0 ? '' : ` target="${linkTarget}"`
+      } else if (href.indexOf('mailto:') < 0) {
+        attrs.target = `"${linkTarget}"`
       }
 
       if (config.target) {
-        attrs += ' target=' + config.target
+        attrs.target = `"${config.target}"`
       }
 
       if (config.disabled) {
-        attrs += ' disabled'
+        attrs.disabled = true
         href = 'javascript:void(0)'
       }
 
       if (title) {
-        attrs += ` title="${title}"`
+        attrs.title = `"${title}"`
       }
 
-      return `<a href="${href}"${attrs}>${text}</a>`
+      const attrsEntries = Object.entries(attrs)
+      let attrsStr = ''
+
+      for (let i = 0; i < attrsEntries.length; ++i) {
+        const [key, value] = attrsEntries[i]
+        attrsStr += ` ${key}=${value}`
+      }
+
+      return `<a href="${href}"${attrsStr}>${text}</a>`
     }
     origin.paragraph = renderer.paragraph = function (text) {
       let result


### PR DESCRIPTION
**Summary**

Fix a bug where if you set `externalLinkTarget`, manual link overrides no longer take effect.

This is a simple logic error where if `config.target` exists on a link, it will get overridden by the global `linkTarget` as things currently stand.

To reproduce the issue, set `externalLinkTarget` to `_self` and change an external link to use the inline `:target=_blank`.

What should happen is that the inline target overrides the global default, but prior to this PR that inline link would still be set to `_self`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome