### PR TITLE
chore: documented __colon__ tip

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -369,6 +369,8 @@ window.$docsify = {
 };
 ```
 
+?> If this options is `false` but you dont want to emojify some specific colons , [Refer this](https://github.com/docsifyjs/docsify/issues/742#issuecomment-586313143)
+
 ## mergeNavbar
 
 - type: `Boolean`

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev": "run-p serve watch:*",
     "dev:ssr": "run-p serve:ssr watch:*",
     "lint": "eslint .",
-    "fixlint" : "eslint . --fix",
+    "fixlint": "eslint . --fix",
     "test": "mocha ./test/**/*.test.js",
     "testServer": "node cypress/setup.js",
     "test:e2e": "start-server-and-test testServer http://localhost:3000 cy:run",
@@ -55,7 +55,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run lint",
+      "npm run fixlint",
       "git add"
     ]
   },


### PR DESCRIPTION
Documented `__colon__` tips to address issues like #745

**Why I added the comment link instead of showing how to do it ?**

Docsify docs is powered by docsify itself. So `__colon__` is converted into `:` in the docs as well.
