### PR TITLE
[fix #1046] fix  cross-origin url cannot be redirected when  "externalLinkTarget" is set to "_self" and "routerMode" is set to "history".

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -66,7 +66,9 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 ```
 
 ## Cross-Origin link
-Only when you set the `routerMode: 'history'` and `externalLinkTarget: '_self'` , you need add this configuration for those Cross-Origin links
+
+Only when you set the `routerMode: 'history'` and `externalLinkTarget: '_self'`, you need add this configuration for those Cross-Origin links.
+
 ```md
 [example.com](https://example.com/ ':crossorgin')  
 ```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -67,7 +67,7 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 
 ## Cross-Origin link
 
-Only when you set the `routerMode: 'history'` and `externalLinkTarget: '_self'`, you need add this configuration for those Cross-Origin links.
+Only when you both set the `routerMode: 'history'` and `externalLinkTarget: '_self'`, you need add this configuration for those Cross-Origin links.
 
 ```md
 [example.com](https://example.com/ ':crossorgin')  

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -66,7 +66,7 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 ```
 
 ## Cross-Origin link
-Only when u set the `routerMode: 'history'` and `externalLinkTarget: '_self'` , you need add this configuration for those Cross-Origin links
+Only when you set the `routerMode: 'history'` and `externalLinkTarget: '_self'` , you need add this configuration for those Cross-Origin links
 ```md
 [example.com](https://example.com/ ':crossorgin')  
 ```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -65,6 +65,12 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set ti
 [link](/demo ':disabled')
 ```
 
+## Cross-Origin link
+Only when u set the `routerMode: 'history'` and `externalLinkTarget: '_self'` , you need add this configuration for those Cross-Origin links
+```md
+[example.com](https://example.com/ ':crossorgin')  
+```
+
 ## Github Task Lists
 
 ```md

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -32,6 +32,7 @@ export default function() {
       externalLinkRel: 'noopener',
       routerMode: 'hash',
       noCompileLinks: [],
+      crossOriginLinks: [],
       relativePath: false,
       topMargin: 0,
     },

--- a/src/core/render/compiler/link.js
+++ b/src/core/render/compiler/link.js
@@ -30,6 +30,17 @@ export const linkCompiler = ({ renderer, router, linkTarget, compilerClass }) =>
       attrs.push(`target="${config.target}"`);
     }
 
+    // special case to check crossorigin urls
+    if (
+      config.crossorgin &&
+      linkTarget === '_self' &&
+      compilerClass.config.routerMode === 'history'
+    ) {
+      if (compilerClass.config.crossOriginLinks.indexOf(href) === -1) {
+        compilerClass.config.crossOriginLinks.push(href);
+      }
+    }
+
     if (config.disabled) {
       attrs.push('disabled');
       href = 'javascript:void(0)';

--- a/src/core/router/history/html5.js
+++ b/src/core/router/history/html5.js
@@ -27,7 +27,12 @@ export class HTML5History extends History {
       if (el.tagName === 'A' && !/_blank/.test(el.target)) {
         e.preventDefault();
         const url = el.href;
-        window.history.pushState({ key: url }, '', url);
+        // solve history.pushState cross-origin issue
+        if (this.config.crossOriginLinks.indexOf(url) !== -1) {
+          window.open(url, '_self');
+        } else {
+          window.history.pushState({ key: url }, '', url);
+        }
         cb({ event: e, source: 'navigate' });
       }
     });


### PR DESCRIPTION
FIX #1046 
Cross-origin url cannot be redirected when  "externalLinkTarget" is set to "_self" and "routerMode" is set to "history".

Now, When  "externalLinkTarget"  set to "_self" and "routerMode", we will use `windows.open`  open url in current page instead.
what you should do is adding the `:crossorigin` next to  ur url
eg:
```md
[example.com](https://example.com/ ':crossorgin')  
```

<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [x] DO NOT include files inside `lib` directory.

