### PR TITLE
default html img resize if no height included

### DIFF
--- a/src/core/render/compiler/image.js
+++ b/src/core/render/compiler/image.js
@@ -22,7 +22,7 @@ export const imageCompiler = ({ renderer, contentBase, router }) =>
       if (height) {
         attrs.push(`width="${width}" height="${height}"`);
       } else {
-        attrs.push(`width="${width}" height="${width}"`);
+        attrs.push(`width="${width}"`);
       }
     }
 

--- a/test/unit/render.test.js
+++ b/test/unit/render.test.js
@@ -168,7 +168,7 @@ text
 
         expectSameDom(
           output,
-          '<p><img src="http://imageUrl" data-origin="http://imageUrl" alt="alt text" width="50" height="50" /></p>'
+          '<p><img src="http://imageUrl" data-origin="http://imageUrl" alt="alt text" width="50" /></p>'
         );
       });
     });


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When image is resized by providing only a `width`, it does not set the `height`. Let html resize automatically to respect the aspect ratio.

Fixes #1064 .

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [ ] DO NOT include files inside `lib` directory.

