### PR TITLE
fix #970, updated the insertion of embedded tokens for async returns

### DIFF
--- a/src/core/render/embed.js
+++ b/src/core/render/embed.js
@@ -1,6 +1,6 @@
+import stripIndent from 'strip-indent';
 import { get } from '../fetch/ajax';
 import { merge } from '../util/core';
-import stripIndent from 'strip-indent';
 
 const cached = {};
 
@@ -117,17 +117,27 @@ export function prerenderEmbed({ compiler, raw = '', fetch }, done) {
     }
   });
 
-  let moveIndex = 0;
+  // keep track of which tokens have been embedded so far
+  // so that we know where to insert the embedded tokens as they
+  // are returned
+  const moves = [];
   walkFetchEmbed({ compile, embedTokens, fetch }, ({ embedToken, token }) => {
     if (token) {
-      const index = token.index + moveIndex;
+      // iterate through the array of previously inserted tokens
+      // to determine where the current embedded tokens should be inserted
+      let index = token.index;
+      moves.forEach(pos => {
+        if (index > pos.start) {
+          index += pos.length;
+        }
+      });
 
       merge(links, embedToken.links);
 
       tokens = tokens
         .slice(0, index)
         .concat(embedToken, tokens.slice(index + 1));
-      moveIndex += embedToken.length - 1;
+      moves.push({ start: index, length: embedToken.length - 1 });
     } else {
       cached[raw] = tokens.concat();
       tokens.links = cached[raw].links = links;


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

fix #970 - updated the insertion of embedded tokens so it correctly handles embedded token results returning in any order

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No


- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [X] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE


**Other information:**

The previous implementation incorrectly assumed that contents of embedded content would be returned in the order they were requested in the document.  This created unpredictable race conditions when multiple embeds were included.

I have run into this issue with embedded markdown, and have only attempted test-cases surrounding the markdown content specifically.

---

* [X ] DO NOT include files inside `lib` directory.

