### PR TITLE
add plugin "words countable"

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -192,6 +192,31 @@ A docsify.js plugin for displaying tabbed content from markdown.
 
 Provided by [@jhildenbiddle](https://github.com/jhildenbiddle/docsify-tabs).
 
+## Words Countable
+
+This is a plugin to add word count for markdown files of docsify.Provided by [@827652549](https://github.com/827652549)
+
+It only counts Chinese characters and English words excludes special characters like `*`、`-`、`……` in markdown file.
+
+**Add JS**
+```html
+<script src="//unpkg.com/docsify-count/dist/countable.js"></script>
+```
+
+**Add settings**
+```js
+window.$docsify = {
+  count:{
+    countable:true,
+    fontsize:'0.9em',
+    color:'rgb(90,90,90)',
+    language:'chinese'
+  }
+}
+```
+
+check [document](https://github.com/827652549/docsify-count)
+
 ## More plugins
 
 See [awesome-docsify](awesome?id=plugins)


### PR DESCRIPTION
This is a plugin to add word count for markdown files of docsify.

<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [ ] DO NOT include files inside `lib` directory.

