### PR TITLE
Updated embed to strip YAML front matter fixes #1129

### DIFF
--- a/docs/_media/example-with-yaml.md
+++ b/docs/_media/example-with-yaml.md
@@ -1,0 +1,6 @@
+---
+author: John Smith
+date: 2020-1-1
+---
+
+> This is from the `example.md`

--- a/docs/embed-files.md
+++ b/docs/embed-files.md
@@ -39,7 +39,20 @@ You will get it
 
 [filename](_media/example.md ':include :type=code')
 
+## Markdown with YAML Front Matter
+
+When using Markdown, YAML front matter will be stripped from the rendered content. The attributes cannot be used in this case.
+
+```markdown
+[filename](_media/example-with-yaml.md ':include')
+```
+
+You will get just the content
+
+[filename](_media/example-with-yaml.md ':include')
+
 ## Embedded code fragments
+
 Sometimes you don't want to embed a whole file. Maybe because you need just a few lines but you want to compile and test the file in CI.
 
 ```markdown
@@ -52,7 +65,6 @@ Alternatively you can use `### [demo]`.
 Example:
 
 [filename](_media/example.js ':include :type=code :fragment=demo')
-
 
 ## Tag attribute
 

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
   </script>
   <script src="/lib/docsify.js"></script>
   <script src="/lib/plugins/search.js"></script>
+  <script src="/lib/plugins/front-matter.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-bash.min.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-markdown.min.js"></script>
   <script src="//unpkg.com/prismjs/components/prism-nginx.min.js"></script>

--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -121,6 +121,21 @@ export class Compiler {
     };
   }
 
+  /**
+   * Pulls content from file and renders inline on the page as a embedded item.
+   *
+   * This allows you to embed different file types on the returned
+   * page.
+   * The basic format is:
+   * ```
+   *   [filename](_media/example.md ':include')
+   * ```
+   *
+   * @param {string}   href   The href to the file to embed in the page.
+   * @param {string}   title  Title of the link used to make the embed.
+   *
+   * @return {type} Return value description.
+   */
   compileEmbed(href, title) {
     const { str, config } = getAndRemoveConfig(title);
     let embed;

--- a/src/core/render/embed.js
+++ b/src/core/render/embed.js
@@ -36,6 +36,13 @@ function walkFetchEmbed({ embedTokens, compile, fetch }, cb) {
               return x;
             });
 
+            // This may contain YAML front matter and will need to be stripped.
+            const frontMatterInstalled =
+              ($docsify.frontMatter || {}).installed || false;
+            if (frontMatterInstalled === true) {
+              text = $docsify.frontMatter.parseMarkdown(text);
+            }
+
             embedToken = compile.lexer(text);
           } else if (token.embed.type === 'code') {
             if (token.embed.fragment) {

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -1,3 +1,23 @@
+/**
+ * Converts a colon formatted string to a object with properties.
+ *
+ * This is process a provided string and look for any tokens in the format
+ * of `:name[=value]` and then convert it to a object and return.
+ * An example of this is ':include :type=code :fragment=demo' is taken and
+ * then converted to:
+ *
+ * ```
+ * {
+ *  include: '',
+ *  type: 'code',
+ *  fragment: 'demo'
+ * }
+ * ```
+ *
+ * @param {string}   str   The string to parse.
+ *
+ * @return {object}  The original string and parsed object, { str, config }.
+ */
 export function getAndRemoveConfig(str = '') {
   const config = {};
 

--- a/src/plugins/front-matter/index.js
+++ b/src/plugins/front-matter/index.js
@@ -1,6 +1,14 @@
 import parser from './parser';
 
 const install = function(hook, vm) {
+  // Used to remove front matter from embedded pages if installed.
+  vm.config.frontMatter = {};
+  vm.config.frontMatter.installed = true;
+  vm.config.frontMatter.parseMarkdown = function(content) {
+    const { body } = parser(content);
+    return body;
+  };
+
   hook.beforeEach(content => {
     const { attributes, body } = parser(content);
 


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

This fixes #1129 where embed was pulling through the YAML header when rendering pages as an embed. I did not want to pull the YAML parser by default. There are no rendering hooks for embed so I added a flag to check to see if the front matter plugin is installed and if it is use it to strip the content before returning the txt to render to the page. 

FYI: I am not a JavaScript developer. :)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [ ] DO NOT include files inside `lib` directory.

