### PR TITLE
Improve accessibility of viewport meta by allowing page zoom (related to #945)

### DIFF
--- a/cypress/fixtures/tpl/docs.index.html
+++ b/cypress/fixtures/tpl/docs.index.html
@@ -16,7 +16,7 @@
     <meta name="description" content="A magical documentation generator." />
     <meta
       name="viewport"
-      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
     />
     <link rel="stylesheet" href="lib/themes/vue.css" title="vue" />
     <link rel="stylesheet" href="lib/themes/dark.css" title="dark" disabled />

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,12 +9,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="keywords" content="doc,docs,documentation,gitbook,creator,generator,github,jekyll,github-pages">
   <meta name="description" content="A magical documentation generator.">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css" title="vue">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/dark.css" title="dark" disabled>
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/buble.css" title="buble" disabled>
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/pure.css" title="pure" disabled>
- 
+
   <script src="//cdn.jsdelivr.net/npm/docsify-plugin-codefund/index.js"></script>
   <link rel="stylesheet"  href="//cdn.jsdelivr.net/npm/docsify-dark-mode@0.6.1/dist/style.css"/>
   <style>

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -68,7 +68,7 @@ You can provide a template for entire page's HTML. such as
 <head>
   <meta charset="UTF-8">
   <title>docsify</title>
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/vue.css" title="vue">
 </head>
 <body>

--- a/packages/docsify-server-renderer/README.md
+++ b/packages/docsify-server-renderer/README.md
@@ -34,7 +34,7 @@ renderer.renderToString(url)
 <head>
   <meta charset="UTF-8">
   <title>docsify</title>
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/themes/buble.css" title="buble" disabled>
 </head>
 <body>

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ if (isSSR) {
   <head>
     <meta charset="UTF-8">
     <title>docsify</title>
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" href="/themes/vue.css" title="vue">
   </head>
   <body>


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Description

Relates to one item mentioned in #945. 

Setting `maximum-scale=1.0` and `user-scalable=no` for the `viewport` meta content has a major detrimental impact on accessibility. Removing these values allows users to optionally zoom and preserves the default experience for other users.

I have made this fix in the default HTML template, but also updated docs and the SSR template.

### References
* [Quick tip: Never use maximum-scale=1.0](https://a11yproject.com/posts/never-use-maximum-scale/) from The A11Y Project
* [Viewport guidelines for browser Zoom](https://web.dev/meta-viewport/) from web.dev (Google)

## Summary

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe: accessibility improvement

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [x] DO NOT include files inside `lib` directory.

