### PR TITLE
fix #1213 

### DIFF
--- a/src/themes/basic/_coverpage.styl
+++ b/src/themes/basic/_coverpage.styl
@@ -22,7 +22,6 @@ section.cover
     flex 1
     margin -20px 16px 0
     text-align center
-    z-index 1
 
   a
     color inherit

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -423,7 +423,7 @@ body.close
     left - $sidebar-width
     transition transform 250ms ease-out
 
-  .content
+  .content, .cover
     left 0
     max-width 100vw
     position static
@@ -441,6 +441,7 @@ body.close
   body.close
     .sidebar, .cover
       transform translateX($sidebar-width)
+      transition transform 250ms ease-out
 
     .sidebar-toggle
       background-color rgba($color-bg, 0.8)

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -439,7 +439,7 @@ body.close
     padding 30px 30px 10px 10px
 
   body.close
-    .sidebar
+    .sidebar, .cover
       transform translateX($sidebar-width)
 
     .sidebar-toggle

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -423,7 +423,7 @@ body.close
     left - $sidebar-width
     transition transform 250ms ease-out
 
-  .content, .cover
+  .content
     left 0
     max-width 100vw
     position static
@@ -439,7 +439,7 @@ body.close
     padding 30px 30px 10px 10px
 
   body.close
-    .sidebar, .cover
+    .sidebar
       transform translateX($sidebar-width)
 
     .sidebar-toggle

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -441,7 +441,6 @@ body.close
   body.close
     .sidebar, .cover
       transform translateX($sidebar-width)
-      transition transform 250ms ease-out
 
     .sidebar-toggle
       background-color rgba($color-bg, 0.8)


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
For devices having a width of `768px` or less the sidebar is overlapped by the cover page
This PR fixes that by sliding the cover page over, similar to the content page

The bug is reproduced by loading the page on a device browser having a screen size of `786px` or less
and clicking the `sidebar-toggle` button

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Before**
![image](https://user-images.githubusercontent.com/32067562/84521650-55f52f80-aca3-11ea-914a-0333c03c58de.png)
**After**
![image](https://user-images.githubusercontent.com/32067562/84521710-6907ff80-aca3-11ea-9b67-cdc238a160cb.png)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**
- Fix #1213 

You have tested in the following browsers: (Providing a detailed version will be better.)

- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

* [X] DO NOT include files inside `lib` directory.

