### PR TITLE
fix: #1210 - Add error handling for missing dependencies

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -29,7 +29,12 @@ async function build(opts) {
           __VERSION__: version,
           'process.env.SSR': false
         })
-      ])
+      ]),
+      onwarn: function (message) {
+        if (message.code === 'UNRESOLVED_IMPORT') {
+          throw new Error(`Could not resolve module ` + message.source)
+        }
+      }
     })
     .then(function (bundle) {
       var dest = 'lib/' + (opts.output || opts.input)

--- a/build/build.js
+++ b/build/build.js
@@ -32,7 +32,7 @@ async function build(opts) {
       ]),
       onwarn: function (message) {
         if (message.code === 'UNRESOLVED_IMPORT') {
-          throw new Error(`Could not resolve module ` + message.source)
+          throw new Error(`Could not resolve module ` + message.source + `. Try running 'npm install'`)
         }
       }
     })

--- a/build/build.js
+++ b/build/build.js
@@ -32,7 +32,12 @@ async function build(opts) {
       ]),
       onwarn: function (message) {
         if (message.code === 'UNRESOLVED_IMPORT') {
-          throw new Error(`Could not resolve module ` + message.source + `. Try running 'npm install'`)
+          throw new Error(
+            `Could not resolve module ` + 
+            message.source + 
+            `. Try running 'npm install' or using rollup's 'external' option if this is an external dependency. ` +
+            `Module ${message.source} is imported in ${message.importer}`
+            )
         }
       }
     })


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
This PR introduces an error handling method for missing dependencies as described in issue #1210 . `onwarn` intercepts warning messages and when `message.code === 'UNRESOLVED_IMPORT'` it means there is an unresolved or missing dependencies. Prior to this PR, a warning message would be logged to the console. The changes made throw an error instead, which can be handled by the appropriate error handler

*Before:*
```
lib/plugins/front-matter.min.js
lib/plugins/front-matter.js
lib/plugins/search.min.js
lib/plugins/search.js
'medium-zoom' is imported by src\plugins\zoom-image.js, but could not be resolved – treating it as an external dependency
'medium-zoom' is imported by src\plugins\zoom-image.js, but could not be resolved – treating it as an external dependency
lib/plugins/zoom-image.min.js
lib/plugins/zoom-image.js
No name was provided for external module 'medium-zoom' in output.globals – guessing 'mediumZoom'
No name was provided for external module 'medium-zoom' in output.globals – guessing 'mediumZoom'
lib/docsify.js
lib/docsify.min.js
```

*After:*
```
lib/plugins/front-matter.js
lib/plugins/front-matter.min.js
Error: Could not resolve module medium-zoom
    at Object.onwarn (C:\Users\simpl\Desktop\docsify\build\build.js:35:17)
    at Graph.onwarn (C:\Users\simpl\Desktop\docsify\node_modules\rollup\dist\shared\index.js:87:25)
    at Graph.warn (C:\Users\simpl\Desktop\docsify\node_modules\rollup\dist\rollup.js:17668:14)
    at ModuleLoader.handleMissingImports (C:\Users\simpl\Desktop\docsify\node_modules\rollup\dist\rollup.js:17239:24)
    at ModuleLoader.<anonymous> (C:\Users\simpl\Desktop\docsify\node_modules\rollup\dist\rollup.js:17288:26)
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\simpl\Desktop\docsify\node_modules\rollup\dist\rollup.js:40:28)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! docsify@4.11.4 build:js: `cross-env NODE_ENV=production node build/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the docsify@4.11.4 build:js script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\simpl\AppData\Roaming\npm-cache\_logs\2020-06-19T19_26_30_901Z-debug.log
```

**Testing methdology**
1) Run `npm install; npm run build:js`. The build should successful. This step is to ensure that there are no problems before deleteing a dependency

2) Take note of the dependencies in `package.json`
https://github.com/docsifyjs/docsify/blob/13f91a4fcb52fb7757e7ecbb4262fd89247dabdd/package.json#L55-70
We will select `medium-zoom` to be the *test* dependecy

4) Delete the appropriate directory from `node_modules` (`node_modules/medium-zoom` for our testing purposes)

5) Execute `npm run build:js`. An error message must be thrown, similar to the one above, labeled *After*

6) Run `npm install; npm run build:js`. The build should successful


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [x] DO NOT include files inside `lib` directory.

