### PR TITLE
Remove bundle size from the home page and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="#backers"><img alt="Backers on Open Collective" src="https://opencollective.com/docsify/backers/badge.svg?style=flat-square"></a>
   <a href="#sponsors">
-    <img alt="Sponsors on Open Collective" src="https://opencollective.com/docsify/sponsors/badge.svg?style=flat-square"></a> 
+    <img alt="Sponsors on Open Collective" src="https://opencollective.com/docsify/sponsors/badge.svg?style=flat-square"></a>
   <a><img src="https://github.com/docsifyjs/docsify/workflows/Unit%20tests%20Suite/badge.svg?branch=develop&amp;event=push" alt="Unit tests Suite"></a>
   <a><img src="https://github.com/docsifyjs/docsify/workflows/Linting%20Checks/badge.svg?branch=develop&amp;event=push" alt="Linting Checks"></a>
   <a><img src="https://github.com/docsifyjs/docsify/workflows/Testing%20the%20e2e%20test%20suites/badge.svg?branch=develop&amp;event=push" alt="Testing the e2e test suites"></a>
@@ -41,7 +41,7 @@
 ## Features
 
 - No statically built html files
-- Simple and lightweight (~21kB gzipped)
+- Simple and lightweight
 - Smart full-text search plugin
 - Multiple themes
 - Useful plugin API

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ See the [Quick start](quickstart.md) guide for more details.
 ## Features
 
 - No statically built html files
-- Simple and lightweight (~21kB gzipped)
+- Simple and lightweight
 - Smart full-text search plugin
 - Multiple themes
 - Useful plugin API

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -4,7 +4,7 @@
 
 > A magical documentation site generator.
 
-- Simple and lightweight (~21kB gzipped)
+- Simple and lightweight
 - No statically built html files
 - Multiple themes
 

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -26,7 +26,7 @@ Set `coverpage` to **true**, and create a `_coverpage.md`:
 
 > A magical documentation site generator.
 
-- Simple and lightweight (~21kB gzipped)
+- Simple and lightweight
 - No statically built html files
 - Multiple themes
 


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe: Just remove bundle size, will create a separate branch for the LighthouseCI

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
fix issue #1211, will create a separate branch for the Lighthouse integration

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE


**Other information:**

---

* [ ] DO NOT include files inside `lib` directory.

