### PR TITLE
Restore `max-width` to `100%` if viewport is less than 768px

### DIFF
--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -430,6 +430,9 @@ body.close
     padding-top 20px
     transition transform 250ms ease
 
+  .markdown-section
+    max-width 80%
+
   .app-nav, .github-corner
     transition transform 250ms ease-out
 

--- a/src/themes/basic/_layout.styl
+++ b/src/themes/basic/_layout.styl
@@ -431,7 +431,7 @@ body.close
     transition transform 250ms ease
 
   .markdown-section
-    max-width 80%
+    max-width 100%
 
   .app-nav, .github-corner
     transition transform 250ms ease-out


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

👇👇👇

It is just to fix a regression introduced by #1017. Before, the `.markdown-section` has `max-width: 800px`, which means its margin-left/right can be 0 if the viewport is narrow (e.g. on mobile devices). But with `max-width: 80%`, there is *always* 20%-wide space no matter how wide the screen is.

This PR restores the `max-width` to `100%` under condition
https://github.com/docsifyjs/docsify/blob/754a2582e27532f8cc9d7ed5d9e73c41d4e535ba/src/themes/basic/_layout.styl#L408

👆👆👆

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.


**Other information:**

---

* [ ] DO NOT include files inside `lib` directory.

