### PR TITLE
fix: gitignore was ignoring folders in src…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 - [ ] Refactor
 - [ ] Docs
 - [ ] Build-related changes
+- [ ] Repo settings
 - [ ] Other, please describe:
 
 If changing the UI of default theme, please provide the **before/after** screenshot:
@@ -44,11 +45,3 @@ If adding a **new feature**, the PR's description includes:
 - [ ] Related tests have been updated
 
 To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-
-
-**Other information:**
-
----
-
-* [ ] DO NOT include files inside `lib` directory.
-

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@
 .DS_Store
 .idea
 node_modules
-themes/
-lib/
-cypress/integration/examples
-cypress/fixtures/docs
+/themes/
+/lib/
+/cypress/integration/examples
+/cypress/fixtures/docs
 
 # exceptions
 !.gitkeep


### PR DESCRIPTION
…so VS Code search results or file fuzzy finder were not working, etc

<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

`.gitignore` was ignoring stuff in the `src` folder. VS Code respects `.gitignore`, so this caused VS Code not to show me search results in files inside of the `src/themes/` folder, and to not be able to open those files using the file palette (fuzzy finder).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe:


**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**

---

* [ ] DO NOT include files inside `lib` directory. **(`/lib` is in gitignore, why do we need this check box?)**