### PR TITLE
Fix #1101, #704

### DIFF
--- a/packages/docsify-server-renderer/index.js
+++ b/packages/docsify-server-renderer/index.js
@@ -178,12 +178,16 @@ export default class Renderer {
     let content;
     try {
       if (isAbsolutePath(filePath)) {
-        const res = await fetch(filePath);
-        if (!res.ok) {
-          throw Error();
-        }
+        if (isExternal(filePath)) {
+          const res = await fetch(filePath);
+          if (!res.ok) {
+            throw Error();
+          }
 
-        content = await res.text();
+          content = await res.text();
+        } else {
+          content = await readFileSync(filePath, 'utf8');
+        }
         this.lock = 0;
       } else {
         content = await readFileSync(filePath, 'utf8');

--- a/src/core/router/history/abstract.js
+++ b/src/core/router/history/abstract.js
@@ -7,7 +7,7 @@ export class AbstractHistory extends History {
     this.mode = 'abstract';
   }
 
-  parse(path) {
+  parse(path = '') {
     let query = '';
 
     const queryIndex = path.indexOf('?');


### PR DESCRIPTION
**Summary**
When updated, SSR won't work for local docs, throwing an error saying `Cannot call 'indexOf' of undefined`.
This fixed the problem by separate file content fetching. When the path is absolute, rather than fetch the content directly, the manner is separated:
- If the path is an external url, use fetch from `node-fetch`
- If the path is a local file with absolute path, just use `readFileSync` 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
