### PR TITLE
fix: Fix search error when exist translations documents

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -213,6 +213,11 @@ export function init(config, vm) {
   const len = paths.length;
   let count = 0;
 
+  // Fix search error when exist translations documents
+  if (INDEXS !== null && !INDEXS[paths[0]]) {
+    INDEXS = {};
+  }
+
   paths.forEach(path => {
     if (INDEXS[path]) {
       return count++;


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Fix search error when exist translations documents.

For example: Chinese documents can be searched in English documents

![image](https://user-images.githubusercontent.com/33931153/88120829-6ed3f780-cbf6-11ea-8df2-acfffc1d6121.png)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
