### PR TITLE
FIX: fallback page should use path not file location

### DIFF
--- a/cypress/fixtures/tpl/docs.index.html
+++ b/cypress/fixtures/tpl/docs.index.html
@@ -28,7 +28,7 @@
       alias: {
         '.*?/awesome':
           'https://raw.githubusercontent.com/docsifyjs/awesome-docsify/master/README.md',
-        '.*?/changelog':
+        '/changelog':
           'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG.md',
         '/.*/_navbar.md': '/_navbar.md',
         '/zh-cn/(.*)':
@@ -40,6 +40,7 @@
         '/es/(.*)':
           'https://raw.githubusercontent.com/docsifyjs/docs-es/master/$1'
       },
+      fallbackLanguages: ['es'],
       auto2top: true,
       coverpage: true,
       executeScript: true,

--- a/cypress/integration/routing/fallback.spec.js
+++ b/cypress/integration/routing/fallback.spec.js
@@ -1,0 +1,9 @@
+context('config.fallbackLanguages', () => {
+  it('fallbacks respecting aliases', () => {
+    cy.visit('http://localhost:3000/#/es/');
+
+    cy.get('.sidebar-nav').contains('Changelog').click();
+
+    cy.get('#main').should('contain', 'Bug Fixes');
+  })
+});

--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -123,7 +123,7 @@ export function fetchMixin(proto) {
           this._loadSideAndNav(path, qs, loadSidebar, cb)
         ),
       _ => {
-        this._fetchFallbackPage(file, qs, cb) || this._fetch404(file, qs, cb);
+        this._fetchFallbackPage(path, qs, cb) || this._fetch404(file, qs, cb);
       }
     );
 

--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -209,7 +209,9 @@ export function fetchMixin(proto) {
       return false;
     }
 
-    const newPath = path.replace(new RegExp(`^/${local}`), '');
+    const newPath = this.router.getFile(
+      path.replace(new RegExp(`^/${local}`), '')
+    );
     const req = request(newPath + qs, true, requestHeaders);
 
     req.then(


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When resolving fallback page for the path (`fallbackLanguages` option), we should consider the original path, not the file location (which could be different when aliases are used).

This patch is used in [this repo](https://github.com/test-prof/docs) and "deployed" at https://test-prof.evilmartians.io/.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
