### PR TITLE
FEAT: add pathNamespaces option to search plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -44,6 +44,17 @@ By default, the hyperlink on the current page is recognized and the content is s
       // To avoid search index collision
       // between multiple websites under the same domain
       namespace: 'website-1',
+
+      // Use different indexes for path prefixes (namespaces).
+      // NOTE: Only works in 'auto' mode.
+      //
+      // When initialiazing an index, we look for the first path from the sidebar.
+      // If it matches the prefix from the list, we switch to the corresponding index.
+      pathNamespaces: ['/zh-cn', '/ru-ru', '/ru-ru/v1'],
+
+      // You can provide a regexp to match prefixes. In this case,
+      // the matching substring will be used to identify the index
+      pathNamespaces: /^(\/(zh-cn|ru-ru))?(\/(v1|v2))?/
     }
   }
 </script>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
           '/de-de/': 'Suche',
           '/zh-cn/': '搜索',
           '/': 'Search'
-        }
+        },
+        pathNamespaces: ['/zh-cn', '/de-de', '/ru-ru', '/es']
       },
       plugins: [
         function (hook, vm) {

--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -10,6 +10,7 @@ const CONFIG = {
   maxAge: 86400000, // 1 day
   hideOtherSidebarContent: false,
   namespace: undefined,
+  pathNamespaces: undefined,
 };
 
 const install = function(hook, vm) {
@@ -27,6 +28,7 @@ const install = function(hook, vm) {
     CONFIG.hideOtherSidebarContent =
       opts.hideOtherSidebarContent || CONFIG.hideOtherSidebarContent;
     CONFIG.namespace = opts.namespace || CONFIG.namespace;
+    CONFIG.pathNamespaces = opts.pathNamespaces || CONFIG.pathNamespaces;
   }
 
   const isAuto = CONFIG.paths === 'auto';

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -198,9 +198,29 @@ export function search(query) {
 
 export function init(config, vm) {
   const isAuto = config.paths === 'auto';
+  const paths = isAuto ? getAllPaths(vm.router) : config.paths;
 
-  const expireKey = resolveExpireKey(config.namespace);
-  const indexKey = resolveIndexKey(config.namespace);
+  let namespaceSuffix = '';
+
+  // only in auto mode
+  if (isAuto && config.pathNamespaces) {
+    const path = paths[0];
+
+    if (Array.isArray(config.pathNamespaces)) {
+      namespaceSuffix =
+        config.pathNamespaces.find(prefix => path.startsWith(prefix)) ||
+        namespaceSuffix;
+    } else if (config.pathNamespaces instanceof RegExp) {
+      const matches = path.match(config.pathNamespaces);
+
+      if (matches) {
+        namespaceSuffix = matches[0];
+      }
+    }
+  }
+
+  const expireKey = resolveExpireKey(config.namespace) + namespaceSuffix;
+  const indexKey = resolveIndexKey(config.namespace) + namespaceSuffix;
 
   const isExpired = localStorage.getItem(expireKey) < Date.now();
 
@@ -212,14 +232,8 @@ export function init(config, vm) {
     return;
   }
 
-  const paths = isAuto ? getAllPaths(vm.router) : config.paths;
   const len = paths.length;
   let count = 0;
-
-  // Fix search error when exist translations documents
-  if (INDEXS !== null && !INDEXS[paths[0]]) {
-    INDEXS = {};
-  }
 
   paths.forEach(path => {
     if (INDEXS[path]) {


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

This option allows to dynamically choose the index path depending on the path prefixes in auto mode. Thus, different path namespace could avoid index intersection (e.g., when having multiple locales):

```js
// complete configuration parameters
    search: {
      // ...
      // Use different indexes for path prefixes (namespaces).
      // NOTE: Only works in 'auto' mode.
      //
      // When initialiazing an index, we look for the first path from the sidebar.
      // If it matches the prefix from the list, we switch to the corresponding index.
      pathNamespaces: ['/zh-cn', '/ru-ru', '/ru-ru/v1'],

      // You can provide a regexp to match prefixes. In this case,
      // the matching substring will be used to identify the index
      pathNamespaces: /^(\/(zh-cn|ru-ru))?(\/(v1|v2))?/
    }
```

Closes #1303.

Array version is used here: [docs.anycable.io](https://github.com/anycable/docs.anycable.io/blob/c723d9941469adbc81fbeae247589f65ba45526c/docs/index.html#L69) ([LIVE](https://docs.anycable.io)).

RegExp version is used here: [test-prof/docs](https://github.com/test-prof/docs/blob/2391e0e6ac206eb4c2138ee2f83be8daade54c43/docs/index.html#L56) ([LIVE](https://test-prof.evilmartians.com)).

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
