### PR TITLE
Convert {docsify-ignore} and {docsify-ignore-all} to HTML comments

### DIFF
--- a/docs/more-pages.md
+++ b/docs/more-pages.md
@@ -114,24 +114,24 @@ A custom sidebar can also automatically generate a table of contents by setting 
 
 ## Ignoring Subheaders
 
-When `subMaxLevel` is set, each header is automatically added to the table of contents by default. If you want to ignore a specific header, add `{docsify-ignore}` to it.
+When `subMaxLevel` is set, each header is automatically added to the table of contents by default. If you want to ignore a specific header, add `<!-- {docsify-ignore} -->` to it.
 
 ```markdown
 # Getting Started
 
-## Header {docsify-ignore}
+## Header <!-- {docsify-ignore} -->
 
 This header won't appear in the sidebar table of contents.
 ```
 
-To ignore all headers on a specific page, you can use `{docsify-ignore-all}` on the first header of the page.
+To ignore all headers on a specific page, you can use `<!-- {docsify-ignore-all} -->` on the first header of the page.
 
 ```markdown
-# Getting Started {docsify-ignore-all}
+# Getting Started <!-- {docsify-ignore-all} -->
 
 ## Header
 
 This header won't appear in the sidebar table of contents.
 ```
 
-Both `{docsify-ignore}` and `{docsify-ignore-all}` will not be rendered on the page when used.
+Both `<!-- {docsify-ignore} -->` and `<!-- {docsify-ignore-all} -->` will not be rendered on the page when used.

--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -208,14 +208,14 @@ export class Compiler {
       let { str, config } = getAndRemoveConfig(text);
       const nextToc = { level, title: str };
 
-      if (/{docsify-ignore}/g.test(str)) {
-        str = str.replace('{docsify-ignore}', '');
+      if (/<!-- {docsify-ignore} -->/g.test(str)) {
+        str = str.replace('<!-- {docsify-ignore} -->', '');
         nextToc.title = str;
         nextToc.ignoreSubHeading = true;
       }
 
-      if (/{docsify-ignore-all}/g.test(str)) {
-        str = str.replace('{docsify-ignore-all}', '');
+      if (/<!-- {docsify-ignore-all} -->/g.test(str)) {
+        str = str.replace('<!-- {docsify-ignore-all} -->', '');
         nextToc.title = str;
         nextToc.ignoreAllSubs = true;
       }

--- a/src/core/render/compiler/headline.js
+++ b/src/core/render/compiler/headline.js
@@ -6,14 +6,14 @@ export const headingCompiler = ({ renderer, router, _self }) =>
     let { str, config } = getAndRemoveConfig(text);
     const nextToc = { level, title: str };
 
-    if (/{docsify-ignore}/g.test(str)) {
-      str = str.replace('{docsify-ignore}', '');
+    if (/<!-- {docsify-ignore} -->/g.test(str)) {
+      str = str.replace('<!-- {docsify-ignore} -->', '');
       nextToc.title = str;
       nextToc.ignoreSubHeading = true;
     }
 
-    if (/{docsify-ignore-all}/g.test(str)) {
-      str = str.replace('{docsify-ignore-all}', '');
+    if (/<!-- {docsify-ignore-all} -->/g.test(str)) {
+      str = str.replace('<!-- {docsify-ignore-all} -->', '');
       nextToc.title = str;
       nextToc.ignoreAllSubs = true;
     }

--- a/test/unit/render.test.js
+++ b/test/unit/render.test.js
@@ -251,6 +251,43 @@ describe('render', function() {
         </h6>`
       );
     });
+
+    it('ignore', async function() {
+      const { docsify } = await init();
+      const output = docsify.compiler.compile(
+        '## h2 tag <!-- {docsify-ignore} -->'
+      );
+      expectSameDom(
+        output,
+        `
+        <h2 id="h2-tag">
+          <a href="#/?id=h2-tag" data-id="h2-tag" class="anchor">
+            <span>h2 tag </span>
+          </a>
+        </h2>`
+      );
+    });
+
+    it('ignore-all', async function() {
+      const { docsify } = await init();
+      const output = docsify.compiler.compile(
+        `# h1 tag <!-- {docsify-ignore-all} -->` + `\n## h2 tag`
+      );
+      expectSameDom(
+        output,
+        `
+        <h1 id="h1-tag">
+          <a href="#/?id=h1-tag" data-id="h1-tag" class="anchor">
+            <span>h1 tag </span>
+          </a>
+        </h1>
+        <h2 id="h2-tag">
+          <a href="#/?id=h2-tag" data-id="h2-tag" class="anchor">
+            <span>h2 tag</span>
+          </a>
+        </h2>`
+      );
+    });
   });
 
   describe('link', function() {


### PR DESCRIPTION
Ref and close #441
This should also close https://github.com/docsifyjs/docsify/issues/767

**Summary**

This PR prevents `{docsify-ignore}` and `{docsify-ignore-all}` to be rendered inside other markdown engines like on Github.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [x] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Tests**

```
$ mocha ./test/**/*.test.js


  router/history/base
    ✓ toURL without relative path
    relativePath true
      ✓ toURL
      ✓ toURL with double dot
      ✓ toURL child path
      ✓ toURL absolute path

  Docsify public API
    ✓ global APIs are available (183ms)
    Docsify config function
      ✓ allows $docsify to be a function (201ms)
      ✓ provides the hooks and vm API to plugins

  render
    ✓ important content (tips)
    lists
      ✓ as unordered task list
      ✓ as ordered task list
      ✓ normal unordered
      ✓ unordered with custom start
      ✓ nested
    image
      ✓ regular
      ✓ class
      ✓ id
      ✓ no-zoom
      size
        ✓ width and height
        ✓ width
    heading
      ✓ h1
      ✓ h2
      ✓ h3
      ✓ h4
      ✓ h5
      ✓ h6
    link
      ✓ regular
      ✓ linkrel
      ✓ disabled
      ✓ target
      ✓ class
      ✓ id

  router/util
    ✓ resolvePath
    ✓ resolvePath with dot
    ✓ resolvePath with two dots


  35 passing (1s)
```
