### PR TITLE
Fixing behaviour for when an link is root-relative #850 #877

### DIFF
--- a/src/core/render/compiler/image.js
+++ b/src/core/render/compiler/image.js
@@ -1,5 +1,10 @@
 import { getAndRemoveConfig } from '../utils';
-import { isAbsolutePath, getPath, getParentPath } from '../../router/util';
+import {
+  isAbsolutePath,
+  isPathRootRelative,
+  getPath,
+  getParentPath,
+} from '../../router/util';
 
 export const imageCompiler = ({ renderer, contentBase, router }) =>
   (renderer.image = (href, title, text) => {
@@ -35,7 +40,9 @@ export const imageCompiler = ({ renderer, contentBase, router }) =>
     }
 
     if (!isAbsolutePath(href)) {
-      url = getPath(contentBase, getParentPath(router.getCurrentPath()), href);
+      url = isPathRootRelative(href)
+        ? getPath(contentBase, href)
+        : getPath(contentBase, getParentPath(router.getCurrentPath()), href);
     }
 
     if (attrs.length > 0) {

--- a/src/core/router/util.js
+++ b/src/core/router/util.js
@@ -44,6 +44,10 @@ export const isAbsolutePath = cached(path => {
   return /(:|(\/{2}))/g.test(path);
 });
 
+export const isPathRootRelative = cached(path => {
+  return path[0] === '/';
+});
+
 export const removeParams = cached(path => {
   return path.split(/[?#]/)[0];
 });


### PR DESCRIPTION
**Summary**

This PR addresses #850 and most likely #877 

When rendering image tags, render the image URL starting from the **base path** if the image URL is root-relative, e.g. `/assets/my-image.png`. Currently, root-relative paths are treated in the same way as normal relative paths which is not consistent with the behaviour of HTML img tags or markedjs compilation output.

**Example**

Given basePath = "" and the current file being `/advanced/guide.md`:

`![](/assets/my-image.png)` previously compiled to `<img src="/advanced/assets/my-image.png></img>`, where it is generally expected to render `<img src="/assets/my-image.png></img>`

This is in line with how HTML `img` tags work and how marked.js compiles its image tags.

**More advanced example**

Given basePath = "/docs/" and directory structure:

```
└── docs
    ├── _sidebar.md
    ├── assets
        ├── my-image.png
    └── subfolder
        ├── _sidebar.md
        ├── guide.md
```

In docs/subfolder/guide.md:

```
![](/assets/my-image.png) --> <img src="/docs/assets/my-image.png></img>
```

While previous behaviour would have been:

```
![](/assets/my-image.png) --> <img src="/docs/subfolder/assets/my-image.png></img>
```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [] No

If yes, please describe the impact and migration path for existing applications:

This can possibly break existing repos who are relying on normal relative path behaviour even when using root-relative paths in their markdown, and hence have images located within subfolders. I have looked through some repos however and could not find any instances of this, since this is generally not how image link URLs are expected to behave.

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome (84)
- [x] Firefox (78)
- [x] Safari (13.1.2)
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
