### PR TITLE
fix: Cannot read property 'startsWith' of undefined

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -208,7 +208,7 @@ export function init(config, vm) {
 
     if (Array.isArray(config.pathNamespaces)) {
       namespaceSuffix =
-        config.pathNamespaces.find(prefix => path.startsWith(prefix)) ||
+        config.pathNamespaces.find(prefix => path && path.startsWith(prefix)) ||
         namespaceSuffix;
     } else if (config.pathNamespaces instanceof RegExp) {
       const matches = path.match(config.pathNamespaces);

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -199,19 +199,18 @@ export function search(query) {
 export function init(config, vm) {
   const isAuto = config.paths === 'auto';
   const paths = isAuto ? getAllPaths(vm.router) : config.paths;
-
   let namespaceSuffix = '';
 
   // only in auto mode
-  if (isAuto && config.pathNamespaces) {
+  if (paths.length && isAuto && config.pathNamespaces) {
     const path = paths[0];
 
     if (Array.isArray(config.pathNamespaces)) {
       namespaceSuffix =
-        config.pathNamespaces.find(prefix => path && path.startsWith(prefix)) ||
+        config.pathNamespaces.find(prefix => path.startsWith(prefix)) ||
         namespaceSuffix;
     } else if (config.pathNamespaces instanceof RegExp) {
-      const matches = path && path.match(config.pathNamespaces);
+      const matches = path.match(config.pathNamespaces);
 
       if (matches) {
         namespaceSuffix = matches[0];

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -199,6 +199,7 @@ export function search(query) {
 export function init(config, vm) {
   const isAuto = config.paths === 'auto';
   const paths = isAuto ? getAllPaths(vm.router) : config.paths;
+
   let namespaceSuffix = '';
 
   // only in auto mode

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -211,7 +211,7 @@ export function init(config, vm) {
         config.pathNamespaces.find(prefix => path && path.startsWith(prefix)) ||
         namespaceSuffix;
     } else if (config.pathNamespaces instanceof RegExp) {
-      const matches = path.match(config.pathNamespaces);
+      const matches = path && path.match(config.pathNamespaces);
 
       if (matches) {
         namespaceSuffix = matches[0];


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

I fixed `#1356` and found another error.

![image](https://user-images.githubusercontent.com/33931153/91242305-a4ca4580-e779-11ea-82ff-2c9f86f44430.png)

```js
    const path = paths[0];

    if (Array.isArray(config.pathNamespaces)) {
      namespaceSuffix =
        config.pathNamespaces.find(prefix => path.startsWith(prefix)) ||
        namespaceSuffix;
    } 
```

`path` is `undefined` when only a readme file is present.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
