### PR TITLE
fix: add missing argument for highlighting code

### DIFF
--- a/src/core/render/compiler/code.js
+++ b/src/core/render/compiler/code.js
@@ -3,11 +3,12 @@ import Prism from 'prismjs';
 import 'prismjs/components/prism-markup-templating';
 
 export const highlightCodeCompiler = ({ renderer }) =>
-  (renderer.code = function(code, lang = '') {
+  (renderer.code = function(code, lang = 'markup') {
     const langOrMarkup = Prism.languages[lang] || Prism.languages.markup;
     const text = Prism.highlight(
       code.replace(/@DOCSIFY_QM@/g, '`'),
-      langOrMarkup
+      langOrMarkup,
+      lang
     );
 
     return `<pre v-pre data-lang="${lang}"><code class="lang-${lang}">${text}</code></pre>`;


### PR DESCRIPTION
<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

the Prism [`highlight()`](https://prismjs.com/docs/Prism.html#.highlight) method requires three arguments:

```
(static) highlight(text, grammar, language) → {string}
```

The last one should be the name of the language. Without the third argument, the `js-templates` (`components/prism-js-templates.js`) component does not work (for highlighting template literals).

Without the third argument:

<img width="599" alt="Zrzut ekranu 2020-09-1 o 10 07 49" src="https://user-images.githubusercontent.com/1906677/91824614-54e8f400-ec3b-11ea-80bc-72a787d9985b.png">

With the third argument:

<img width="597" alt="Zrzut ekranu 2020-09-1 o 10 08 38" src="https://user-images.githubusercontent.com/1906677/91824646-603c1f80-ec3b-11ea-8858-89de535f7ea3.png">


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Repo settings
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
