### PR TITLE
fix: Use legacy-compatible methods for IE11

### DIFF
--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -73,7 +73,7 @@ export function fetchMixin(proto) {
       case 'object':
         key = Object.keys(notFoundPage)
           .sort((a, b) => b.length - a.length)
-          .find(k => path.match(new RegExp('^' + k)));
+          .filter(k => path.match(new RegExp('^' + k)))[0];
 
         path404 = (key && notFoundPage[key]) || defaultPath;
         break;

--- a/src/core/render/compiler/link.js
+++ b/src/core/render/compiler/link.js
@@ -29,7 +29,7 @@ export const linkCompiler = ({
 
       href = router.toURL(href, null, router.getCurrentPath());
     } else {
-      if (!isAbsolutePath(href) && href.startsWith('./')) {
+      if (!isAbsolutePath(href) && href.slice(0, 2) === './') {
         href =
           document.URL.replace(/\/(?!.*\/).*/, '/').replace('#/./', '') + href;
       }

--- a/src/core/render/embed.js
+++ b/src/core/render/embed.js
@@ -26,7 +26,7 @@ function walkFetchEmbed({ embedTokens, compile, fetch }, cb) {
             // Resolves relative links to absolute
             text = text.replace(/\[([^[\]]+)\]\(([^)]+)\)/g, x => {
               const linkBeginIndex = x.indexOf('(');
-              if (x.substring(linkBeginIndex).startsWith('(.')) {
+              if (x.slice(linkBeginIndex, linkBeginIndex + 2) === '(.') {
                 return (
                   x.substring(0, linkBeginIndex) +
                   `(${window.location.protocol}//${window.location.host}${path}/` +

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -255,8 +255,10 @@ export function renderMixin(proto) {
 
     if (hideSidebar) {
       // FIXME : better styling solution
-      document.querySelector('aside.sidebar').remove();
-      document.querySelector('button.sidebar-toggle').remove();
+      [
+        document.querySelector('aside.sidebar'),
+        document.querySelector('button.sidebar-toggle'),
+      ].forEach(node => node.parentNode.removeChild(node));
       document.querySelector('section.content').style.right = 'unset';
       document.querySelector('section.content').style.left = 'unset';
       document.querySelector('section.content').style.position = 'relative';

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -245,8 +245,9 @@ export function init(config, vm) {
 
     if (Array.isArray(config.pathNamespaces)) {
       namespaceSuffix =
-        config.pathNamespaces.find(prefix => path.startsWith(prefix)) ||
-        namespaceSuffix;
+        config.pathNamespaces.filter(
+          prefix => path.slice(0, prefix.length) === prefix
+        )[0] || namespaceSuffix;
     } else if (config.pathNamespaces instanceof RegExp) {
       const matches = path.match(config.pathNamespaces);
 


### PR DESCRIPTION
**Summary**

Modern convenience methods like `Array.prototype.find()` and `String.prototype.startsWith()` are not compatible with legacy browsers like IE11. This PR replaces those methods with legacy-compatible approaches that accomplish the same thing.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [x] IE