### PR TITLE
Fix: Theme preview in IE11

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,23 +2,27 @@
 
 There is a handful of themes available, both official and community-made. Copy [Vue](//vuejs.org) and [buble](//buble.surge.sh) website custom theme and [@liril-net](https://github.com/liril-net) contribution to the theme of the black style.
 
+<!-- prettier-ignore-start -->
 ```html
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/vue.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/buble.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/dark.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/pure.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/vue.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/buble.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/dark.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/pure.css" />
 ```
+<!-- prettier-ignore-end -->
 
 !> Compressed files are available in `/lib/themes/`.
 
+<!-- prettier-ignore-start -->
 ```html
 <!-- compressed -->
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/buble.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/dark.css">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/pure.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/buble.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/dark.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/pure.css" />
 ```
+<!-- prettier-ignore-end -->
 
 If you have any ideas or would like to develop a new theme, you are welcome to submit a [pull request](https://github.com/docsifyjs/docsify/pulls).
 
@@ -47,10 +51,10 @@ If you have any ideas or would like to develop a new theme, you are welcome to s
   var themes = Docsify.dom.findAll('[rel="stylesheet"]');
 
   preview.onclick = function (e) {
-    var title = e.target.getAttribute('data-theme')
+    var title = e.target.getAttribute('data-theme');
 
     themes.forEach(function (theme) {
-      theme.disabled = theme.title !== title
+      theme.disabled = theme.title !== title;
     });
   };
 </script>


### PR DESCRIPTION
**Summary**

IE11 was throwing an error when loading the "Themes" page due to missing semicolons in the page `<script>`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [x] IE