### PR TITLE
fix: isExternal check with malformed URL + tests

### DIFF
--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -22,7 +22,7 @@ function loadNested(path, qs, file, next, vm, first) {
 
 function isExternal(url) {
   let match = url.match(
-    /^([^:/?#]+:)?(?:\/\/([^/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/
+    /^([^:/?#]+:)?(?:\/{2,}([^/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/
   );
   if (
     typeof match[1] === 'string' &&

--- a/test/e2e/security.test.js
+++ b/test/e2e/security.test.js
@@ -1,0 +1,32 @@
+const docsifyInit = require('../helpers/docsify-init');
+
+describe(`Security`, function() {
+  const sharedOptions = {
+    markdown: {
+      homepage: '# Hello World',
+    },
+    routes: {
+      'test.md': '# Test Page',
+    },
+  };
+
+  describe(`Cross Site Scripting (XSS)`, function() {
+    const slashStrings = ['//', '///'];
+
+    for (const slashString of slashStrings) {
+      const hash = `#${slashString}domain.com/file.md`;
+
+      test(`should not load remote content from hash (${hash})`, async () => {
+        await docsifyInit(sharedOptions);
+        await expect(page).toHaveText('#main', 'Hello World');
+        await page.evaluate(() => (location.hash = '#/test'));
+        await expect(page).toHaveText('#main', 'Test Page');
+        await page.evaluate(newHash => {
+          location.hash = newHash;
+        }, hash);
+        await expect(page).toHaveText('#main', 'Hello World');
+        expect(page.url()).toMatch(/#\/$/);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Fix #1477. Fix #1126. Follow-up to #1489.

**Summary**

Handles malformed remote URLs that contain more than two forward slashes (e.g., `////////domain.com/file.md`)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE