### PR TITLE
allow user configured navbar selection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,19 @@ window.$docsify = {
 };
 ```
 
+## nav_el
+
+- Type: `String`
+- Default: `null`
+
+The DOM element to use for rendering the navbar. It can be a CSS selector string or an actual [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement).  If `null`, the first `<nav>` element on the page is used. If it doesn't exist, it is created at the top of the DOM.
+
+```js
+window.$docsify = {
+  nav_el: '#navbar,
+};
+```
+
 ## loadSidebar
 
 - Type: `Boolean|String`

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -294,7 +294,8 @@ export function renderMixin(proto) {
   };
 
   proto._renderNav = function(text) {
-    text && this._renderTo('nav', this.compiler.compile(text));
+    text &&
+      this._renderTo(this.config.nav_el || 'nav', this.compiler.compile(text));
     if (this.config.loadNavbar) {
       getAndActive(this.router, 'nav');
     }
@@ -401,7 +402,7 @@ export function initRender(vm) {
   }
 
   const id = config.el || '#app';
-  const navEl = dom.find('nav') || dom.create('nav');
+  const navEl = dom.find(config.nav_el || 'nav') || dom.create('nav');
 
   const el = dom.find(id);
   let html = '';
@@ -444,7 +445,7 @@ export function initRender(vm) {
   }
 
   // Add nav
-  if (config.loadNavbar) {
+  if (config.loadNavbar && !config.nav_el) {
     dom.before(navAppendToTarget, navEl);
   }
 


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

`render/index.js` selects the first `<nav>` element on the page to use as docsify's navbar.  This makes embedding on existing pages problematic when the page already includes a `<nav>`.  This change adds a `nav_el` config option that allows selecting which navbar to use on the page, in the same manner as the `el` option.

There are a few key behaviors implemented:

- if `nav_el` is not found, fall back to selecting the first `<nav>` tag
- if `nav_el` is defined, do not try to append to the top of the DOM

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

Feature

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

https://github.com/docsifyjs/docsify/issues/1525

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
