### PR TITLE
fix: Add escapeHtml for search

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -178,7 +178,7 @@ export function search(query) {
       keywords.forEach(keyword => {
         // From https://github.com/sindresorhus/escape-string-regexp
         const regEx = new RegExp(
-          ignoreDiacriticalMarks(keyword).replace(
+          escapeHtml(ignoreDiacriticalMarks(keyword)).replace(
             /[|\\{}()[\]^$+*?.]/g,
             '\\$&'
           ),
@@ -187,10 +187,10 @@ export function search(query) {
         let indexTitle = -1;
         let indexContent = -1;
         handlePostTitle = postTitle
-          ? ignoreDiacriticalMarks(postTitle)
+          ? escapeHtml(ignoreDiacriticalMarks(postTitle))
           : postTitle;
         handlePostContent = postContent
-          ? ignoreDiacriticalMarks(postContent)
+          ? escapeHtml(ignoreDiacriticalMarks(postContent))
           : postContent;
 
         indexTitle = postTitle ? handlePostTitle.search(regEx) : -1;


### PR DESCRIPTION
## **Summary**

`escapeHtml` was removed in support of search accents, which may cause some problems. #1549

After adding it question 2 will appear again. https://github.com/docsifyjs/docsify/pull/1434#pullrequestreview-552172033

What's the best way to do it? 

## **What kind of change does this PR introduce?**

Bugfix

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

close #1549

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
