### PR TITLE
fix: buble theme missing generic fallback font

### DIFF
--- a/src/themes/buble.styl
+++ b/src/themes/buble.styl
@@ -101,14 +101,14 @@ $sidebar-width = 16rem
 .markdown-section code
   background-color #f9f9f9
   border-radius 3px
-  font-family Inconsolata
+  font-family Inconsolata, monospace
   padding 0.2em 0.4rem
   white-space nowrap
 
 .markdown-section pre
   background-color #f9f9f9
   border-left 2px solid #eee
-  font-family Inconsolata
+  font-family Inconsolata, monospace
   font-size 16px
   margin 0 0 1em 0
   padding 8px
@@ -159,7 +159,7 @@ $sidebar-width = 16rem
   background-color #f8f8f8
   border-radius 2px
   display block
-  font-family Inconsolata
+  font-family Inconsolata, monospace
   line-height 1.1rem
   max-width inherit
   overflow inherit


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

buble theme missing generic fallback font

close #1565

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
