### PR TITLE
HTML escape included mermaid files to handle embedded tags

### DIFF
--- a/src/core/render/embed.js
+++ b/src/core/render/embed.js
@@ -63,7 +63,13 @@ function walkFetchEmbed({ embedTokens, compile, fetch }, cb) {
             );
           } else if (token.embed.type === 'mermaid') {
             embedToken = [
-              { type: 'html', text: `<div class="mermaid">\n${text}\n</div>` },
+              {
+                type: 'html',
+                text: `<div class="mermaid">\n${text
+                  .replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/"/g, '&quot;')}\n</div>`,
+              },
             ];
             embedToken.links = {};
           } else {


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

Fixes an issue where included mermaid files that had embedded tags failed to render, due to the file being included verbatim into the <div> tag, and embedded html within the mermaid file "breaking out" of the div.

e.g. the following mermaid file will fail:
```
graph TB
  linkStyle default fill:#ffffff

  14["&lt;div style='font-weight: bold'&gt;This will break&lt;/div&gt;&lt;div style='font-size: 70%; margin-top: 0px'&gt;[Software System]&lt;/div&gt;&lt;div style='font-size: 80%; margin-top:10px'&gt;Description&lt;br /&gt;with HTML&lt;/div&gt;"]
```


## **What kind of change does this PR introduce?**

  Bugfix

## **For any code change,**

- [X] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added
There are no tests that test in the include functionality

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

## **Related issue, if any:**

## **Tested in the following browsers:**

- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [X] Edge
- [ ] IE
