### PR TITLE
fix: allow also " inside of an embed

### DIFF
--- a/docs/embed-files.md
+++ b/docs/embed-files.md
@@ -16,7 +16,7 @@ Then the content of `example.md` will be displayed directly here;
 
 You can check the original content for [example.md](_media/example.md ':ignore').
 
-Normally, this will compiled into a link, but in docsify, if you add `:include` it will be embedded.
+Normally, this will compiled into a link, but in docsify, if you add `:include` it will be embedded. You can use single or double quotation marks around as you like.
 
 External links can be used too - just replace the target. If you want to use a gist URL, see [Embed a gist](#embed-a-gist) section.
 

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -23,8 +23,8 @@ export function getAndRemoveConfig(str = '') {
 
   if (str) {
     str = str
-      .replace(/^'/, '')
-      .replace(/'$/, '')
+      .replace(/^('|")/, '')
+      .replace(/('|")$/, '')
       .replace(/(?:^|\s):([\w-]+:?)=?([\w-%]+)?/g, (m, key, value) => {
         if (key.indexOf(':') === -1) {
           config[key] = (value && value.replace(/&quot;/g, '')) || true;

--- a/test/unit/render-util.test.js
+++ b/test/unit/render-util.test.js
@@ -1,4 +1,7 @@
-const { removeAtag } = require('../../src/core/render/utils');
+const {
+  removeAtag,
+  getAndRemoveConfig,
+} = require('../../src/core/render/utils');
 
 const { tree } = require(`../../src/core/render/tpl`);
 
@@ -14,6 +17,46 @@ describe('core/render/utils', () => {
       const result = removeAtag('<a href="www.example.com">content</a>');
 
       expect(result).toEqual('content');
+    });
+  });
+
+  // getAndRemoveConfig()
+  // ---------------------------------------------------------------------------
+  describe('getAndRemoveConfig()', () => {
+    test('parse simple config', () => {
+      const result = getAndRemoveConfig(
+        `[filename](_media/example.md ':include')`
+      );
+
+      expect(result).toMatchObject({
+        config: {},
+        str: `[filename](_media/example.md ':include')`,
+      });
+    });
+
+    test('parse config with arguments', () => {
+      const result = getAndRemoveConfig(
+        `[filename](_media/example.md ':include :foo=bar :baz test')`
+      );
+
+      expect(result).toMatchObject({
+        config: {
+          foo: 'bar',
+          baz: true,
+        },
+        str: `[filename](_media/example.md ':include test')`,
+      });
+    });
+
+    test('parse config with double quotes', () => {
+      const result = getAndRemoveConfig(
+        `[filename](_media/example.md ":include")`
+      );
+
+      expect(result).toMatchObject({
+        config: {},
+        str: `[filename](_media/example.md ":include")`,
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

I fixed a bug where `":include"` is not handled like `':include'`. This is not working because the type of quotes are not supported. The default prettier configuration changes the `''` to `""`. And if you have auto format toggled on, you're not be able to save the file with the right quotes.

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

I added added the `"` also the the replace regex

```js
str = str
      .replace(/^('|")/, '')
      .replace(/('|")$/, '')
```

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added (I cant find some tests for that already.)

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

closes #1597 
closes #1587 
closes #1555 
closes #1005 

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
