### PR TITLE
docs: improve English wording (Getting Started/Customization)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ window.$docsify = {
 - Type: `String`
 - Default: `null`
 
-Configure the repository url, or a string of `username/repo` can add the [GitHub Corner](http://tholman.com/github-corners/) widget in the top right corner of the site.
+Configure the repository url, or a string of `username/repo`, to add the [GitHub Corner](http://tholman.com/github-corners/) widget in the top right corner of the site.
 
 ```js
 window.$docsify = {
@@ -260,7 +260,7 @@ window.$docsify = {
 
 - Type: `String`
 
-Website logo as it appears in the sidebar. You can resize it by using CSS.
+Website logo as it appears in the sidebar. You can resize it using CSS.
 
 ```js
 window.$docsify = {
@@ -337,7 +337,7 @@ window.$docsify = {
 
 - Type: `String`
 
-Customize the theme color. Use [CSS3 variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) feature and polyfill in old browser.
+Customize the theme color. Use [CSS3 variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) feature and polyfill in older browsers.
 
 ```js
 window.$docsify = {
@@ -367,7 +367,7 @@ window.$docsify = {
 
 - type: `Boolean`
 
-If `loadSidebar` and `autoHeader` are both enabled, for each link in `_sidebar.md`, prepend a header to the page before converting it to HTML. Compare [#78](https://github.com/docsifyjs/docsify/issues/78).
+If `loadSidebar` and `autoHeader` are both enabled, for each link in `_sidebar.md`, prepend a header to the page before converting it to HTML. See [#78](https://github.com/docsifyjs/docsify/issues/78).
 
 ```js
 window.$docsify = {
@@ -380,7 +380,7 @@ window.$docsify = {
 
 - type: `Boolean`
 
-Execute the script on the page. Only parse the first script tag([demo](themes)). If Vue is present, it is turned on by default.
+Execute the script on the page. Only parse the first script tag ([demo](themes)). If Vue is present, it is turned on by default.
 
 ```js
 window.$docsify = {
@@ -410,7 +410,7 @@ window.$docsify = {
 };
 ```
 
-?> If this options is `false` but you don't want to emojify some specific colons , [Refer this](https://github.com/docsifyjs/docsify/issues/742#issuecomment-586313143)
+?> If this option is `false` but you don't want to emojify some specific colons, [refer to this](https://github.com/docsifyjs/docsify/issues/742#issuecomment-586313143)
 
 ## mergeNavbar
 
@@ -497,8 +497,8 @@ window.$docsify = {
 
 - type: `Array`
 
-When `routerMode: 'history'`, you may face the cross-origin issues, See [#1379](https://github.com/docsifyjs/docsify/issues/1379).
-In Markdown content, there is a simple way to solve it, see extends Markdown syntax `Cross-Origin link` in [helpers](helpers.md).
+When `routerMode: 'history'`, you may face cross-origin issues. See [#1379](https://github.com/docsifyjs/docsify/issues/1379).
+In Markdown content, there is a simple way to solve it: see extends Markdown syntax `Cross-Origin link` in [helpers](helpers.md).
 
 ```js
 window.$docsify = {
@@ -570,7 +570,7 @@ window.$docsify = {
 
 - type: `Array<string>`
 
-List of languages that will fallback to the default language when a page is requested and it doesn't exist for the given local.
+List of languages that will fallback to the default language when a page is requested and it doesn't exist for the given locale.
 
 Example:
 
@@ -615,14 +615,14 @@ window.$docsify = {
 };
 ```
 
-> Note: The options with fallbackLanguages didn't work with the `notFoundPage` options.
+> Note: The options for fallbackLanguages don't work with the `notFoundPage` options.
 
 ## topMargin
 
 - type: `Number`
 - default: `0`
 
-Adds a space on top when scrolling content page to reach the selected section. This is useful in case you have a _sticky-header_ layout and you want to align anchors to the end of your header.
+Adds a space on top when scrolling the content page to reach the selected section. This is useful in case you have a _sticky-header_ layout and you want to align anchors to the end of your header.
 
 ```js
 window.$docsify = {

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -1,6 +1,6 @@
 # Cover
 
-Activate the cover feature by setting `coverpage` to **true**, compare [coverpage configuration](configuration.md#coverpage).
+Activate the cover feature by setting `coverpage` to **true**. See [coverpage configuration](configuration.md#coverpage).
 
 ## Basic usage
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -15,9 +15,9 @@ window.$docsify = {
 }
 ```
 
-?> Configuration Options Reference [marked documentation](https://marked.js.org/#/USING_ADVANCED.md)
+?> Configuration Options Reference: [marked documentation](https://marked.js.org/#/USING_ADVANCED.md)
 
-Even you can completely customize the parsing rules.
+You can completely customize the parsing rules.
 
 ```js
 window.$docsify = {

--- a/docs/more-pages.md
+++ b/docs/more-pages.md
@@ -25,7 +25,7 @@ docs/zh-cn/guide.md   => http://domain.com/#/zh-cn/guide
 
 ## Sidebar
 
-In order to have sidebar, then you can create your own `_sidebar.md` (see [this documentation's sidebar](https://github.com/docsifyjs/docsify/blob/master/docs/_sidebar.md) for an example):
+In order to have a sidebar, you can create your own `_sidebar.md` (see [this documentation's sidebar](https://github.com/docsifyjs/docsify/blob/master/docs/_sidebar.md) for an example):
 
 First, you need to set `loadSidebar` to **true**. Details are available in the [configuration paragraph](configuration.md#loadsidebar).
 
@@ -65,7 +65,7 @@ Example file structure:
 
 ## Nested Sidebars
 
-You may want the sidebar to update with only navigation to reflect the current directory. This can be done by adding a `_sidebar.md` file to each folder.
+You may want the sidebar to update after navigation to reflect the current directory. This can be done by adding a `_sidebar.md` file to each folder.
 
 `_sidebar.md` is loaded from each level directory. If the current directory doesn't have `_sidebar.md`, it will fall back to the parent directory. If, for example, the current path is `/guide/quick-start`, the `_sidebar.md` will be loaded from `/guide/_sidebar.md`.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,7 +123,7 @@ Exclude the special image
 
 ## Edit on github
 
-Add `Edit on github` button on every pages. Provided by [@njleonzhang](https://github.com/njleonzhang), check [document](https://github.com/njleonzhang/docsify-edit-on-github)
+Add `Edit on github` button on every pages. Provided by [@njleonzhang](https://github.com/njleonzhang), see this [document](https://github.com/njleonzhang/docsify-edit-on-github)
 
 ## Demo code with instant preview and jsfiddle integration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,7 +81,7 @@ If you prefer to lock docsify to a specific version, specify the full version af
 
 ### Manually preview your site
 
-If you installed python on your system, you can easily use it to run a static server to preview your site.
+If you have Python installed on your system, you can easily use it to run a static server to preview your site.
 
 ```python2
 cd docs && python -m SimpleHTTPServer 3000

--- a/docs/write-a-plugin.md
+++ b/docs/write-a-plugin.md
@@ -49,7 +49,7 @@ window.$docsify = {
 
 #### footer
 
-Add footer component in each pages.
+Add a footer component to each page.
 
 ```js
 window.$docsify = {


### PR DESCRIPTION
While referencing the documentation, I noticed a few phrases that could
be changed to sound more natural. I tried to keep the original meanings.

<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

This change improves the phrasing of the English translation of the documentation. It uses more natural sounding English phrases. Only two sections are covered in this PR: the Getting Started and Customization sections.

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

No UI changes.

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

Docs

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [x] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE
