### PR TITLE
fix: files from basePath should be remoteUrl:false

### DIFF
--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -76,12 +76,13 @@ export function fetchMixin(proto) {
   };
 
   proto._fetch = function(cb = noop) {
+    const { basePath } = this.config;
     const { query } = this.route;
     let { path } = this.route;
 
     // Prevent loading remote content via URL hash
     // Ex: https://foo.com/#//bar.com/file.md
-    if (isExternal(path)) {
+    if (isExternal(path, basePath)) {
       history.replaceState(null, '', '#');
       this.router.normalize();
     } else {
@@ -92,7 +93,7 @@ export function fetchMixin(proto) {
       const file = this.router.getFile(path);
       const req = request(file + qs, true, requestHeaders);
 
-      this.isRemoteUrl = isExternal(file);
+      this.isRemoteUrl = isExternal(file, basePath);
       // Current page is html
       this.isHTML = /\.html$/g.test(file);
 

--- a/src/core/util/core.js
+++ b/src/core/util/core.js
@@ -72,10 +72,20 @@ export function isFn(obj) {
  * @param {String} string  url
  * @returns {Boolean} True if the passed-in url is external
  */
-export function isExternal(url) {
-  let match = url.match(
-    /^([^:/?#]+:)?(?:\/{2,}([^/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/
-  );
+export function isExternal(url, basePath) {
+  const regExp = /^([^:/?#]+:)?(?:\/{2,}([^/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/;
+  let match = url.match(regExp);
+
+  if (basePath) {
+    const matchWithBasePath = basePath.match(regExp);
+    if (
+      match && matchWithBasePath &&
+      match[1] === matchWithBasePath[1] &&
+      match[2] === matchWithBasePath[2]
+    ) {
+      return false;
+    }
+  }
 
   if (
     typeof match[1] === 'string' &&


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

Currently, files fetched from `basePath` are treated as `isExternal: true` , and I think this behavior is a bug.

`basePath` is a value that can be entered only with the authority of the document site administrator, and the `basePath` server can also be considered owned by the administrator, so the `isRemoteUrl` value should be `false`.

## **What kind of change does this PR introduce?**

Bugfix

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**
#1659 

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
