### PR TITLE
add build:test and docker:build:test scripts to allow devs to test bo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint .",
     "fixlint": "eslint . --fix",
     "test": "jest",
+    "build:test": "npm run build && npm test",
     "test:e2e": "jest --selectProjects e2e",
     "test:integration": "jest --selectProjects integration",
     "test:unit": "jest --selectProjects unit",
@@ -47,10 +48,12 @@
     "docker:build": "docker build -f Dockerfile -t docsify-test:local .",
     "docker:clean": "docker rmi docsify-test:local",
     "docker:rebuild": "npm run docker:clean && npm run docker:build",
-    "docker:test": "docker run --rm -it --ipc=host --mount type=bind,source=$(pwd)/test,target=/app/test docsify-test:local test",
-    "docker:test:e2e": "docker run --rm -it --ipc=host --mount type=bind,source=$(pwd)/test,target=/app/test docsify-test:local test:e2e",
-    "docker:test:integration": "docker run --rm -it --ipc=host --mount type=bind,source=$(pwd)/test,target=/app/test docsify-test:local test:integration",
-    "docker:test:unit": "docker run --rm -it --ipc=host --mount type=bind,source=$(pwd)/test,target=/app/test docsify-test:local test:unit"
+    "docker:test": "npm run docker:cli -- test",
+    "docker:build:test": "npm run docker:cli -- build:test",
+    "docker:test:e2e": "npm run docker:cli -- test:e2e",
+    "docker:test:integration": "npm run docker:cli -- test:integration",
+    "docker:test:unit": "npm run docker:cli -- test:unit",
+    "docker:cli": "docker run --rm -it --ipc=host --mount type=bind,source=$(pwd)/test,target=/app/test docsify-test:local"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
…th build and tests at the same time

The docker:rebuild script rebuilds the docker image from scratch including the Docsify build, while the new one rebuilds only Docsify code and makes local re-testing faster.

<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [x] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
