### PR TITLE
fix: Coverpage when content > viewport height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 .DS_Store
 .idea
 *.log
-_playwright-report
-_playwright-results
-lib
-node_modules
-themes
+/_playwright-report
+/_playwright-results
+/lib
+/node_modules
+/themes
 
 # exceptions
 !.gitkeep

--- a/src/themes/basic/_coverpage.styl
+++ b/src/themes/basic/_coverpage.styl
@@ -1,10 +1,11 @@
 section.cover
+  position relative
   align-items center
   background-position center center
   background-repeat no-repeat
   background-size cover
-  height 100vh
-  width 100vw
+  min-height 100vh
+  width 100%
   display none
 
   &.show
@@ -15,12 +16,12 @@ section.cover
     opacity 0.8
     position absolute
     top 0
-    height 100%
+    bottom 0
     width 100%
 
   .cover-main
     flex 1
-    margin -20px 16px 0
+    margin 0 16px
     text-align center
     position: relative
 


### PR DESCRIPTION
## **Summary**

Fix #381. Replacement PR for #1514.

**Before:**

<img width="340" alt="CleanShot 2022-02-03 at 00 21 05@2x" src="https://user-images.githubusercontent.com/442527/152293736-4d9b4a8a-b75d-456a-94ea-62054820d204.png">

<img width="344" alt="CleanShot 2022-02-03 at 00 21 30@2x" src="https://user-images.githubusercontent.com/442527/152293750-f2b84c07-176b-4d0e-bfbc-70c067e5c2ea.png">

**After:**

<img width="354" alt="CleanShot 2022-02-03 at 00 20 00@2x" src="https://user-images.githubusercontent.com/442527/152293772-b1c27ee0-36f0-46f3-8f7a-bafe540a81ea.png">

<img width="352" alt="CleanShot 2022-02-03 at 00 20 26@2x" src="https://user-images.githubusercontent.com/442527/152293784-86be214e-2c50-450e-9bc5-3e608f980ecc.png">

<img width="339" alt="CleanShot 2022-02-03 at 00 33 28@2x" src="https://user-images.githubusercontent.com/442527/152293798-818dcd2e-be9f-405c-9675-1c1c9afb7ce5.png">

<img width="337" alt="CleanShot 2022-02-03 at 00 33 48@2x" src="https://user-images.githubusercontent.com/442527/152293811-8cd220cf-6940-4488-8e89-1ffd55674809.png">

## **What kind of change does this PR introduce?**

Fix

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

#381

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE
