### PR TITLE
Fix: ready/doneEach order with async afterEach

### DIFF
--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -321,15 +321,15 @@ export function Render(Base) {
             );
           }
 
-          this.callHook('afterEach', html, hookData =>
-            renderMain.call(this, hookData)
-          );
+          this.callHook('afterEach', html, hookData => {
+            renderMain.call(this, hookData);
+            next();
+          });
         };
 
         if (this.isHTML) {
           html = this.result = text;
           callback();
-          next();
         } else {
           prerenderEmbed(
             {
@@ -339,7 +339,6 @@ export function Render(Base) {
             tokens => {
               html = this.compiler.compile(tokens);
               callback();
-              next();
             }
           );
         }

--- a/test/e2e/plugins.test.js
+++ b/test/e2e/plugins.test.js
@@ -9,7 +9,7 @@ test.describe('Plugins', () => {
       'mounted',
       'beforeEach-async',
       'beforeEach',
-      // 'afterEach-async',
+      'afterEach-async',
       'afterEach',
       'doneEach',
       'ready',
@@ -41,13 +41,12 @@ test.describe('Plugins', () => {
               return markdown;
             });
 
-            // FIXME: https://github.com/docsifyjs/docsify/issues/449
-            // hook.afterEach(function (html, next) {
-            //   setTimeout(function () {
-            //     console.log('afterEach-async');
-            //     next(html);
-            //   }, 100);
-            // });
+            hook.afterEach(function (html, next) {
+              setTimeout(function () {
+                console.log('afterEach-async');
+                next(html);
+              }, 100);
+            });
 
             hook.afterEach(function (html) {
               console.log('afterEach');


### PR DESCRIPTION
fix #449 (see for details)

## **Summary**

- Fix invocation order of `doneEach` and `ready` hooks  when using asynchronous `afterEach` hook(s).
- Update plugin tests to verify hook order

**Before**

`doneEach` and `ready` hooks are properly invoked after all _synchronous_ `afterEach` hooks are complete.

```
afterEach() - Sync
afterEach() - Sync
afterEach() - Sync
doneEach()
ready()
// ** Content rendered **
```

With asynchronous `afterEach` hooks, `doneEach` and `ready` hook are improperly invoked before the first async `afterEach` hook.

```
afterEach() - Sync
doneEach()           // <-- Bug
ready()              // <-- Bug
afterEach() - Async
afterEach() - Sync
// ** Content rendered **
```

**After**

`doneEach` and `ready` hooks are invoked after all `afterEach` hooks are complete, regardless of sync/async.

```
afterEach() - Sync
afterEach() - Async
afterEach() - Sync
doneEach()           // <-- Fixed
ready()              // <-- Fixed
// ** Content rendered **
```

## **What kind of change does this PR introduce?**

Bugfix

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [x] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

#449 

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE
