### PR TITLE
Patch history mode path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [4.12.3](https://github.com/docsifyjs/docsify/compare/v4.12.2...v4.12.3) (2022-07-07)
+
+
+### Bug Fixes
+
+* Add a doc wrapper el to scope the event listener to the doc itself instead on the full window by default ([8d5624d](https://github.com/docsifyjs/docsify/commit/8d5624db96de2b524643bf3baf63e52af6add2d2))
+* cornerExternalLinkTarget config. ([#1814](https://github.com/docsifyjs/docsify/issues/1814)) ([54cc5f9](https://github.com/docsifyjs/docsify/commit/54cc5f939b9499ae56604f589eef4e3f1c13cdc5))
+* correctly fix missing +1, -1 ([#1722](https://github.com/docsifyjs/docsify/issues/1722)) ([719dcbe](https://github.com/docsifyjs/docsify/commit/719dcbea5cb0c8b0835f8e9fc473b094feecb7ec))
+* Coverpage when content > viewport height ([#1744](https://github.com/docsifyjs/docsify/issues/1744)) ([301b516](https://github.com/docsifyjs/docsify/commit/301b5169613e95765eda335a4b21d0f9f9cbbbfd)), closes [#381](https://github.com/docsifyjs/docsify/issues/381)
+* Legacy bugs (styles, site plugin error, and dev server error) ([#1743](https://github.com/docsifyjs/docsify/issues/1743)) ([fa6df6d](https://github.com/docsifyjs/docsify/commit/fa6df6d58487ec294e22be04ac159dfb5745bd66))
+* package.json & package-lock.json to reduce vulnerabilities ([#1756](https://github.com/docsifyjs/docsify/issues/1756)) ([2dc5b12](https://github.com/docsifyjs/docsify/commit/2dc5b12b715e3ad1922a6401e3fd9837a99ef9c0))
+* packages/docsify-server-renderer/package.json & packages/docsify-server-renderer/package-lock.json to reduce vulnerabilities ([#1715](https://github.com/docsifyjs/docsify/issues/1715)) ([c1227b2](https://github.com/docsifyjs/docsify/commit/c1227b22cb8a3fb6c362ca8ac109082ab2251cc3))
+
+
+### Features
+
+* Emoji build ([#1766](https://github.com/docsifyjs/docsify/issues/1766)) ([ba5ee26](https://github.com/docsifyjs/docsify/commit/ba5ee26f00e957b58173f96b1901f6ffd3d8e5f5))
+* Native emoji w/ image-based fallbacks and improved parsing ([#1746](https://github.com/docsifyjs/docsify/issues/1746)) ([35002c9](https://github.com/docsifyjs/docsify/commit/35002c92b762f0d12e51582d7de7914fa380596a)), closes [#779](https://github.com/docsifyjs/docsify/issues/779)
+* Plugin error handling ([#1742](https://github.com/docsifyjs/docsify/issues/1742)) ([63b2535](https://github.com/docsifyjs/docsify/commit/63b2535a45a98945ec897277f4fbddec2ddba887))
+
+
+
 ## [4.12.2](https://github.com/docsifyjs/docsify/compare/v4.12.1...v4.12.2) (2022-01-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.12.4](https://github.com/docsifyjs/docsify/compare/v4.12.3...v4.12.4) (2022-07-07)
+
+
+### Bug Fixes
+
+* docsify doc wrapper element not found ([4153a4a](https://github.com/docsifyjs/docsify/commit/4153a4a20ea82927931a5acf2f6cda27a19a0a57))
+
+
+
 ## [4.12.3](https://github.com/docsifyjs/docsify/compare/v4.12.2...v4.12.3) (2022-07-07)
 
 

--- a/build/release.sh
+++ b/build/release.sh
@@ -12,7 +12,7 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   echo "Releasing $VERSION ..."
 
-  # Removing test script as non - availibity of tests. Will Add it once tests are completed 
+  # Removing test script as non - availibity of tests. Will Add it once tests are completed
 
   # npm run test
 
@@ -23,9 +23,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   cd packages/docsify-server-renderer
   npm version $VERSION
   if [[ -z $RELEASE_TAG ]]; then
-    npm publish
+    npm publish --access public
   else
-    npm publish --tag $RELEASE_TAG
+    npm publish --tag $RELEASE_TAG --access public
   fi
   cd -
 
@@ -45,8 +45,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   git push origin refs/tags/v$VERSION
   git push
   if [[ -z $RELEASE_TAG ]]; then
-    npm publish
+    npm publish --access public
   else
-    npm publish --tag $RELEASE_TAG
+    npm publish --tag $RELEASE_TAG --access public
   fi
 fi

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,6 +1,6 @@
 ![logo](_media/icon.svg)
 
-# docsify <small>4.12.2</small>
+# docsify <small>4.12.3</small>
 
 > A magical documentation site generator.
 

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,6 +1,6 @@
 ![logo](_media/icon.svg)
 
-# docsify <small>4.12.3</small>
+# docsify <small>4.12.4</small>
 
 > A magical documentation site generator.
 

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
         maxLevel: 4,
         subMaxLevel: 2,
         name: 'docsify',
+        routerMode: 'history',
         nameLink: {
           '/es/': '#/es/',
           '/de-de/': '#/de-de/',

--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@
   </head>
 
   <body>
-    <div id="app"></div>
+    <div class="doc-wrapper">
+      <div id="app"></div>
+    </div>
     <script src="//cdn.jsdelivr.net/npm/docsify-plugin-carbon@1"></script>
     <script>
       // Set html "lang" attribute based on URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "docsify",
+  "name": "@developerportalsg/docsify",
   "version": "4.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "docsify",
+      "name": "@developerportalsg/docsify",
       "version": "4.12.2",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@developerportalsg/docsify",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@developerportalsg/docsify",
-      "version": "4.12.3",
+      "version": "4.12.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@developerportalsg/docsify",
-  "version": "4.12.2",
+  "version": "4.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@developerportalsg/docsify",
-      "version": "4.12.2",
+      "version": "4.12.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developerportalsg/docsify",
-  "version": "4.12.2",
+  "version": "4.12.3",
   "description": "A magical documentation generator.",
   "author": {
     "name": "qingwei-li",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docsify",
+  "name": "@developerportalsg/docsify",
   "version": "4.12.2",
   "description": "A magical documentation generator.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developerportalsg/docsify",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "description": "A magical documentation generator.",
   "author": {
     "name": "qingwei-li",

--- a/packages/docsify-server-renderer/package-lock.json
+++ b/packages/docsify-server-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsify-server-renderer",
-  "version": "4.12.2",
+  "version": "4.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "docsify-server-renderer",
-      "version": "4.12.2",
+      "version": "4.12.3",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.3",

--- a/packages/docsify-server-renderer/package-lock.json
+++ b/packages/docsify-server-renderer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsify-server-renderer",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "docsify-server-renderer",
-      "version": "4.12.3",
+      "version": "4.12.4",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.3",

--- a/packages/docsify-server-renderer/package.json
+++ b/packages/docsify-server-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developerportalsg/docsify-server-renderer",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "description": "docsify server renderer",
   "author": {
     "name": "qingwei-li",

--- a/packages/docsify-server-renderer/package.json
+++ b/packages/docsify-server-renderer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docsify-server-renderer",
+  "name": "@developerportalsg/docsify-server-renderer",
   "version": "4.12.2",
   "description": "docsify server renderer",
   "author": {

--- a/packages/docsify-server-renderer/package.json
+++ b/packages/docsify-server-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developerportalsg/docsify-server-renderer",
-  "version": "4.12.2",
+  "version": "4.12.3",
   "description": "docsify server renderer",
   "author": {
     "name": "qingwei-li",

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -14,6 +14,7 @@ export default function (vm) {
       coverpage: '',
       crossOriginLinks: [],
       el: '#app',
+      docWrapperEl: '.doc-wrapper',
       executeScript: null,
       ext: '.md',
       externalLinkRel: 'noopener',

--- a/src/core/router/history/base.js
+++ b/src/core/router/history/base.js
@@ -45,7 +45,10 @@ export class History {
 
     path = config.alias ? getAlias(path, config.alias) : path;
     path = getFileName(path, ext);
-    path = path === `/README${ext}` ? config.homepage || path : path;
+    path =
+      path === cleanPath(config.nameLink + '/README' + ext)
+        ? cleanPath([config.nameLink, config.homepage].join('/')) || path
+        : path;
     path = isAbsolutePath(path) ? path : getPath(base, path);
 
     if (isRelative) {

--- a/src/core/router/history/html5.js
+++ b/src/core/router/history/html5.js
@@ -20,8 +20,9 @@ export class HTML5History extends History {
     return (path || '/') + window.location.search + window.location.hash;
   }
 
-  onchange(cb = noop) {
-    on('click', e => {
+  onchange(cb = noop, docWrapperEl) {
+    on(docWrapperEl ? docWrapperEl : window, 'click', e => {
+      // For backward compatibility, since not all doc has a doc wrapper element
       const el = e.target.tagName === 'A' ? e.target : e.target.parentNode;
 
       if (el && el.tagName === 'A' && !/_blank/.test(el.target)) {

--- a/src/core/router/index.js
+++ b/src/core/router/index.js
@@ -61,7 +61,7 @@ export function Router(Base) {
 
         this.$fetch(noop, this.$resetEvents.bind(this, params.source));
         lastRoute = this.route;
-      });
+      }, dom.find(this.config.docWrapperEl));
     }
   };
 }


### PR DESCRIPTION
## **Summary**

Patching docsify doc path for history mode so that the docs can add {doc}/{slug} to its path to enable the homepage to be loaded without README.md or homepage.md

For example, 
Without Homepage configuration:
https://docs.developer.gov.sg/docs/{slug}/README.md 
With Homepage configuration:
https://docs.developer.gov.sg/docs/{slug}/home.md

Expected In docsify history mode, https://docs.developer.gov.sg/docs/{slug}/
 
## **What kind of change does this PR introduce?**
Bugfix

## **Does this PR introduce a breaking change?** (check one)

- [x ] No
## **Tested in the following browsers:**

- [x ] Chrome
- [x] Firefox
- [x ] Safari
- [x] Edge
- [x] IE
