### PR TITLE
Docs: Fix plugin insertion order in docs

### DIFF
--- a/docs/write-a-plugin.md
+++ b/docs/write-a-plugin.md
@@ -22,6 +22,8 @@ window.$docsify = {
 Alternatively, a plugin can be stored in a separate file and "installed" using a standard `<script>` tag:
 
 ```js
+// docsify-plugin-myplugin.js
+
 (function () {
   var myPlugin = function (hook, vm) {
     // ...
@@ -29,7 +31,7 @@ Alternatively, a plugin can be stored in a separate file and "installed" using a
 
   // Add plugin to docsify's plugin array
   $docsify = $docsify || {};
-  $docsify.plugins = [].concat(myPlugin, $docsify.plugins || []);
+  $docsify.plugins = [].concat($docsify.plugins || [], myPlugin);
 })();
 ```
 


### PR DESCRIPTION
## **Summary**

This simple change to the plugin template provided in the docs ensures that plugins are inserted into the `$docsify.plugins` array in the order that the `<script>` tags appear in the DOM. Before this change, plugins were always inserted at the beginning of the plugins array which can (and has) caused issues when the order of plugin execution is important.

## **What kind of change does this PR introduce?**

Docs

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No