### PR TITLE
fix: When alias contains parameters, append ext error

### DIFF
--- a/src/core/router/history/base.js
+++ b/src/core/router/history/base.js
@@ -26,7 +26,9 @@ function getFileName(path, ext) {
     ? path
     : /\/$/g.test(path)
     ? `${path}README${ext}`
-    : `${path}${ext}`;
+    : path.indexOf('?') === -1
+    ? `${path}${ext}`
+    : path;
 }
 
 export class History {


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

As mentioned in #1854, if the URL used by the alias contains parameters, we will add the 'ext' configuration item incorrectly

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

Bugfix

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

Fix #1854

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
