### PR TITLE
fix: fix search with no content.

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -211,14 +211,15 @@ export function search(query) {
           }
 
           const matchContent =
+            handlePostContent &&
             '...' +
-            handlePostContent
-              .substring(start, end)
-              .replace(
-                regEx,
-                word => `<em class="search-keyword">${word}</em>`
-              ) +
-            '...';
+              handlePostContent
+                .substring(start, end)
+                .replace(
+                  regEx,
+                  word => `<em class="search-keyword">${word}</em>`
+                ) +
+              '...';
 
           resultStr += matchContent;
         }

--- a/test/e2e/search.test.js
+++ b/test/e2e/search.test.js
@@ -176,4 +176,24 @@ test.describe('Search Plugin Tests', () => {
     await searchFieldElm.fill('hello');
     await expect(resultsHeadingElm).toHaveText('Changelog Title');
   });
+  test('search when there is no body', async ({ page }) => {
+    const docsifyInitConfig = {
+      markdown: {
+        homepage: `
+          # EmptyContent
+          ---
+          ---
+        `,
+      },
+      scriptURLs: ['/lib/plugins/search.min.js'],
+    };
+
+    const searchFieldElm = page.locator('input[type=search]');
+    const resultsHeadingElm = page.locator('.results-panel h2');
+
+    await docsifyInit(docsifyInitConfig);
+
+    await searchFieldElm.fill('empty');
+    await expect(resultsHeadingElm).toHaveText('EmptyContent');
+  });
 });


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**
When the content is empty, the `postContent` of `post.body` is `undifined`, therefore, here will get ex while `substring` on an `undefined` str `handlePostContent`.
```md
## Header with no content
---
---
## Normal
Some content here
```
<img width="500" alt="image" src="https://user-images.githubusercontent.com/33706142/189607213-7ceb1ea2-73d7-4e87-98bd-53545b780b6c.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/33706142/189607745-0c4e304f-40f9-4f01-85a0-3ff2fb5c7c5d.png">

close #1876

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->
Bugfix
<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [x] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
