### PR TITLE
fix: filter null node first.

### DIFF
--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -260,7 +260,9 @@ export function Render(Base) {
         [
           document.querySelector('aside.sidebar'),
           document.querySelector('button.sidebar-toggle'),
-        ].forEach(node => node.parentNode.removeChild(node));
+        ]
+          .filter(e => !!e)
+          .forEach(node => node.parentNode.removeChild(node));
         document.querySelector('section.content').style.right = 'unset';
         document.querySelector('section.content').style.left = 'unset';
         document.querySelector('section.content').style.position = 'relative';


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**
fix #1907 

When query and remove the sidebar again, there contains `["null","null"]` nodes for removing  which already moved.
<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
