### PR TITLE
fix: solved navigation to same link error

### DIFF
--- a/src/core/router/history/hash.js
+++ b/src/core/router/history/hash.js
@@ -46,6 +46,15 @@ export class HashHistory extends History {
     let navigating = false;
 
     on('click', e => {
+      let hashArray = location.hash.split('?id=');
+      if (
+        e.target.tagName === 'A' &&
+        hashArray.length === 2 &&
+        e.target.text.toLowerCase().replaceAll(' ', '-') === hashArray[1]
+      ) {
+        history.pushState(null, null, hashArray[0]);
+      }
+
       const el = e.target.tagName === 'A' ? e.target : e.target.parentNode;
 
       if (el && el.tagName === 'A' && !/_blank/.test(el.target)) {


### PR DESCRIPTION
## **Summary**

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

Fixed issue where, after clicking one of the anchors on the sidebar, if the user scrolled throughout the page and changed section, it would not allow the navigation to the same id/anchor (Would not re scroll to the same clicked previously)

## **What kind of change does this PR introduce?**

  Bugfix

## **For any code change,**

- [ ] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

Couldn't find any applicable doc or tests, let me know if I missed any.

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ X ] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

#1899 

## **Tested in the following browsers:**

- [ X ] Chrome
- [ X ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
