### PR TITLE
Added alwaysScrollHeader option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,19 @@ window.$docsify = {
 };
 ```
 
+## alwaysScrollHeader
+
+- Type: `Boolean`
+- Default: `false`
+
+Always scrolls to ID/header when specified in route. By default, page will use browser's scroll auto-restoration.
+
+```js
+window.$docsify = {
+  alwaysScrollHeader: true,
+};
+```
+
 ## autoHeader
 
 - Type: `Boolean`

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -7,6 +7,7 @@ export default function (vm) {
   const config = merge(
     {
       auto2top: false,
+      alwaysScrollHeader: false,
       autoHeader: false,
       basePath: '',
       catchPluginErrors: true,

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -12,12 +12,12 @@ import { scrollIntoView, scroll2Top } from './scroll';
 export function Events(Base) {
   return class Events extends Base {
     $resetEvents(source) {
-      const { auto2top } = this.config;
+      const { auto2top, alwaysScrollHeader } = this.config;
 
       (() => {
-        // Rely on the browser's scroll auto-restoration when going back or forward
+        // If alwaysScrollHeader is false (default), rely on the browser's scroll auto-restoration when going back or forward
         if (source === 'history') {
-          return;
+          alwaysScrollHeader && scrollIntoView(this.route.path, this.route.query.id);
         }
         // Scroll to ID if specified
         if (this.route.query.id) {


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

In Firefox, the browser's auto-restore scroll position feature doesn't work correctly when navigating via history. I have not tried it in other browsers. I added this feature for myself but I figured I should contribute it in case someone finds it useful, and since is a very small change.

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**
- Feature
- Docs
<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
