### PR TITLE
ref #1803: fix cross-origin links in history router mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,19 +140,6 @@ window.$docsify = {
 };
 ```
 
-## crossOriginLinks
-
-- Type: `Array`
-
-When `routerMode: 'history'`, you may face cross-origin issues. See [#1379](https://github.com/docsifyjs/docsify/issues/1379).
-In Markdown content, there is a simple way to solve it: see extends Markdown syntax `Cross-Origin link` in [helpers](helpers.md).
-
-```js
-window.$docsify = {
-  crossOriginLinks: ['https://example.com/cross-origin-link'],
-};
-```
-
 ## el
 
 - Type: `String`
@@ -688,6 +675,7 @@ window.$docsify = {
 Define "virtual" routes that can provide content dynamically. A route is a map between the expected path, to either a string or a function. If the mapped value is a string, it is treated as markdown and parsed accordingly. If it is a function, it is expected to return markdown content.
 
 A route function receives up to three parameters:
+
 1. `route` - the path of the route that was requested (e.g. `/bar/baz`)
 2. `matched` - the [`RegExpMatchArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) that was matched by the route (e.g. for `/bar/(.+)`, you get `['/bar/baz', 'baz']`)
 3. `next` - this is a callback that you may call when your route function is async
@@ -701,23 +689,23 @@ window.$docsify = {
     '/foo': '# Custom Markdown',
 
     // RegEx match w/ synchronous function
-    '/bar/(.*)': function(route, matched) {
+    '/bar/(.*)': function (route, matched) {
       return '# Custom Markdown';
     },
 
     // RegEx match w/ asynchronous function
-    '/baz/(.*)': function(route, matched, next) {
-       // Requires `fetch` polyfill for legacy browsers (https://github.github.io/fetch/)
+    '/baz/(.*)': function (route, matched, next) {
+      // Requires `fetch` polyfill for legacy browsers (https://github.github.io/fetch/)
       fetch('/api/users?id=12345')
-        .then(function(response) {
+        .then(function (response) {
           next('# Custom Markdown');
         })
-        .catch(function(err) {
+        .catch(function (err) {
           // Handle error...
         });
-    }
-  }
-}
+    },
+  },
+};
 ```
 
 Other than strings, route functions can return a falsy value (`null` \ `undefined`) to indicate that they ignore the current request:

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -65,14 +65,6 @@ You will get `<a href="/demo/">link</a>`html. Do not worry, you can still set th
 [link](/demo ':disabled')
 ```
 
-## Cross-Origin link
-
-Only when you set both the `routerMode: 'history'` and `externalLinkTarget: '_self'`, you need to add this configuration for those Cross-Origin links.
-
-```md
-[example.com](https://example.com/ ':crossorgin')
-```
-
 ## GitHub Task Lists
 
 ```md

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -12,7 +12,6 @@ export default function (vm) {
       catchPluginErrors: true,
       cornerExternalLinkTarget: '_blank',
       coverpage: '',
-      crossOriginLinks: [],
       el: '#app',
       executeScript: null,
       ext: '.md',

--- a/src/core/render/compiler/link.js
+++ b/src/core/render/compiler/link.js
@@ -43,17 +43,6 @@ export const linkCompiler = ({
       );
     }
 
-    // special case to check crossorigin urls
-    if (
-      config.crossorgin &&
-      linkTarget === '_self' &&
-      compilerClass.config.routerMode === 'history'
-    ) {
-      if (compilerClass.config.crossOriginLinks.indexOf(href) === -1) {
-        compilerClass.config.crossOriginLinks.push(href);
-      }
-    }
-
     if (config.disabled) {
       attrs.push('disabled');
       href = 'javascript:void(0)';

--- a/src/core/router/history/hash.js
+++ b/src/core/router/history/hash.js
@@ -1,4 +1,4 @@
-import { noop } from '../../util/core';
+import { isExternal, noop } from '../../util/core';
 import { on } from '../../util/dom';
 import { endsWith } from '../../util/str';
 import { parseQuery, cleanPath, replaceSlug } from '../util';
@@ -48,7 +48,7 @@ export class HashHistory extends History {
     on('click', e => {
       const el = e.target.tagName === 'A' ? e.target : e.target.parentNode;
 
-      if (el && el.tagName === 'A' && !/_blank/.test(el.target)) {
+      if (el && el.tagName === 'A' && !isExternal(el.href)) {
         navigating = true;
       }
     });

--- a/src/core/router/history/html5.js
+++ b/src/core/router/history/html5.js
@@ -1,4 +1,4 @@
-import { noop } from '../../util/core';
+import { isExternal, noop } from '../../util/core';
 import { on } from '../../util/dom';
 import { parseQuery, getPath } from '../util';
 import { History } from './base';
@@ -24,15 +24,10 @@ export class HTML5History extends History {
     on('click', e => {
       const el = e.target.tagName === 'A' ? e.target : e.target.parentNode;
 
-      if (el && el.tagName === 'A' && !/_blank/.test(el.target)) {
+      if (el && el.tagName === 'A' && !isExternal(el.href)) {
         e.preventDefault();
         const url = el.href;
-        // solve history.pushState cross-origin issue
-        if (this.config.crossOriginLinks.indexOf(url) !== -1) {
-          window.open(url, '_self');
-        } else {
-          window.history.pushState({ key: url }, '', url);
-        }
+        window.history.pushState({ key: url }, '', url);
         cb({ event: e, source: 'navigate' });
       }
     });


### PR DESCRIPTION
the crossOriginLinks option is no longer needed, remove misspelled "crossorgin" link helper, and instead detect cross origin links and don't handle them as internal

<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

External links are now navigable by default when `routerMode` is `history`, regardless of the `externalLinksTarget` value. 

The `crossOriginLinks` option was added as a way to force external links to not be handled as internal.

Instead, that feature has been removed, and now we use `isExternal` to check for external links, and avoid handling them as internal.

The value of an `<a>` tag's `target` is no longer used as our external link check.


## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

  Bugfix
  Docs

<!--
  Feature
  Code style update
  Refactor
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

The `crossOriginLinks` option is now ignored. I don't think this is breaking. I think people want external links to work properly, so at worst some people will have listed all their links in that array, but now they don't have to.

Thinking of tests to add...

## **Related issue, if any:**

fixes https://github.com/docsifyjs/docsify/issues/1803

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ ] IE (of course not!)
