### PR TITLE
(WIP, DO NOT MERGE) routerMode:history for the docsify site

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!-- 404 redirect for single page apps on GitHub pages, copied as instructed from
+https://github.com/rafgraph/spa-github-pages. -->
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Single Page Apps for GitHub Pages</title>
+		<script type="text/javascript">
+			// Single Page Apps for GitHub Pages
+			// MIT License
+			// https://github.com/rafgraph/spa-github-pages
+			// This script takes the current url and converts the path and query
+			// string into just a query string, and then redirects the browser
+			// to the new url with only a query string and hash fragment,
+			// e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+			// https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+			// Note: this 404.html file must be at least 512 bytes for it to work
+			// with Internet Explorer (it is currently > 512 bytes)
+
+			// If you're creating a Project Pages site and NOT using a custom domain,
+			// then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+			// This way the code will only replace the route part of the path, and not
+			// the real directory in which the app resides, for example:
+			// https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+			// https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+			// Otherwise, leave pathSegmentsToKeep as 0.
+			var pathSegmentsToKeep = 0
+
+			var l = window.location
+			l.replace(
+				l.protocol +
+					'//' +
+					l.hostname +
+					(l.port ? ':' + l.port : '') +
+					l.pathname
+						.split('/')
+						.slice(0, 1 + pathSegmentsToKeep)
+						.join('/') +
+					'/?/' +
+					l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+					(l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+					l.hash,
+			)
+		</script>
+	</head>
+	<body>
+		<h1>404</h1>
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,34 @@
         width: auto !important;
       }
     </style>
+
+		<!-- Start Single Page Apps for GitHub Pages -->
+		<!-- Copied/adapted as instructed from https://github.com/rafgraph/spa-github-pages. -->
+		<script type="text/javascript">
+			// Single Page Apps for GitHub Pages
+			// MIT License
+			// https://github.com/rafgraph/spa-github-pages
+			// This script checks to see if a redirect is present in the query string,
+			// converts it back into the correct url and adds it to the
+			// browser's history using window.history.replaceState(...),
+			// which won't cause the browser to attempt to load the new url.
+			// When the single page app is loaded further down in this file,
+			// the correct url will be waiting in the browser's history for
+			// the single page app to route accordingly.
+			;(function (l) {
+				if (l.search[1] === '/') {
+					var decoded = l.search
+						.slice(1)
+						.split('&')
+						.map(function (s) {
+							return s.replace(/~and~/g, '&')
+						})
+						.join('?')
+					window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash)
+				}
+			})(window.location)
+		</script>
+		<!-- End Single Page Apps for GitHub Pages -->
   </head>
 
   <body>
@@ -35,6 +63,8 @@
 
       // Docsify configuration
       window.$docsify = {
+        routerMode: 'history',
+        externalLinkTarget: '_self',
         alias: {
           '.*?/awesome':
             'https://raw.githubusercontent.com/docsifyjs/awesome-docsify/master/README.md',

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const liveServer = require('live-server')
 const isSSR = !!process.env.SSR
 const middleware = []
@@ -46,10 +48,30 @@ if (isSSR) {
   })
 }
 
+// emulate default behavior of GitHub Pages and other static servers that
+// serve a 404.html page when files are not found.
+middleware.push(
+  /**
+   * @param {import('http').IncomingMessage} req
+   * @param {import('http').ServerResponse} res
+   * @param {(error?: Error) => void} res
+   */
+  function (req, res, next) {
+    if (!fs.existsSync(path.resolve('.' + req.url))) {
+      console.log(res.statusCode = 404)
+    }
+    next();
+  }
+)
+
 const params = {
   port: 3000,
   watch: ['lib', 'docs', 'themes'],
-  middleware
+  middleware,
+
+  // emulate default behavior of GitHub Pages and other static servers that
+  // serve a 404.html page when files are not found.
+  file: '404.html',
 }
 
 liveServer.start(params)


### PR DESCRIPTION
WIP, DO NOT MERGE

<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

This allows us to deploy the Docsify site to a static server that handles unknown URLs with a default `404.html` page, for example GitHub Pages.

As an example, https://docs.lume.io is published on GitHub pages. Notice that the URLs are in `history` mode, and you can refresh the site while on any path, and it works. Pushing to the github repo automatically updates the deployment using this [GitHub Actions file](https://github.com/lume/lume.github.io/blob/main/.github/workflows/build.yml).

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Build-related changes
  Other
-->

  Repo settings

  Docs


<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ ] IE (nope!)
