### PR TITLE
chore: remove codesandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,0 @@
-{
-  "sandboxes": ["2d17z"],
-  "packages": ["."],
-  "node": "16"
-}

--- a/sandbox.config.json
+++ b/sandbox.config.json
@@ -1,4 +1,0 @@
-{
-  "template": "node",
-  "node": "16"
-}


### PR DESCRIPTION
We have GitHub Action and Vercel, so we can eliminate the need for codesandbox.

And codesandbox limits the build memory, so it often fails.

