### PR TITLE
chore: add missing Vue support for Vercel builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,58 @@
           },
           pathNamespaces: ['/es', '/de-de', '/ru-ru', '/zh-cn'],
         },
+        vueComponents: {
+          'button-counter': {
+            template: /* html */ `<button @click="count += 1">You clicked me {{ count }} times</button>`,
+            data() {
+              return {
+                count: 0,
+              };
+            },
+          },
+        },
+        vueGlobalOptions: {
+          data() {
+            return {
+              count: 0,
+              message: 'Hello, World!',
+              // Fake API response
+              images: [
+                { title: 'Image 1', url: 'https://picsum.photos/150?random=1' },
+                { title: 'Image 2', url: 'https://picsum.photos/150?random=2' },
+                { title: 'Image 3', url: 'https://picsum.photos/150?random=3' },
+              ],
+            };
+          },
+          computed: {
+            timeOfDay() {
+              const date = new Date();
+              const hours = date.getHours();
+
+              if (hours < 12) {
+                return 'morning';
+              } else if (hours < 18) {
+                return 'afternoon';
+              } else {
+                return 'evening';
+              }
+            },
+          },
+          methods: {
+            hello() {
+              alert(this.message);
+            },
+          },
+        },
+        vueMounts: {
+          '#counter': {
+            data() {
+              return {
+                count: 0,
+              };
+            },
+          },
+        },
         plugins: [
           DocsifyCarbon.create('CEBI6KQE', 'docsifyjsorg'),
           function (hook, vm) {
@@ -121,5 +173,7 @@
     <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-markdown.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-nginx.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-php.min.js"></script>
+
+    <script src="//cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

We currently have two `index.html` files (why is that again?). One file was not loading Vue stuff.

Without the Vue support in Vercel builds, we were unable to fully verify pull request builds, therefore unable to confirm if Vue broke or not. Now we can manually check Vue functionality for PRs.

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

Add Vue support to the index.html file that didn't have it.

## **For any code change,**

- [x] Related documentation has been updated if needed
- [x] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
