### PR TITLE
update(doc): fix themeColor in configuration.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -838,11 +838,13 @@ For more details, see [#1131](https://github.com/docsifyjs/docsify/issues/1131).
 
 > **Warning** Deprecated. Use the CSS var `--theme-color` in your `<style>` sheet. Example:
 >
-> <style>
->   :root {
->     --theme-color: deeppink;
->   }
-> </style>
+```html
+<style>
+   :root {
+     --theme-color: deeppink;
+   }
+</style>
+```
 
 - Type: `String`
 


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**
Fix the `themeColor` config doc changed in #2114 .
```
> <style>
>   :root {
>     --theme-color: deeppink;
>   }
> </style>
```
the markdown takes a mistake to treat it as HTML style. See [Pink Configuration preview](https://docsify-preview-git-fix-vue-in-vercel-deployments-docsifyjs.vercel.app/#/configuration) as reproduct.

### And, it seems also brings a new feature that we could allow user set `theme-color` per markdown page . 🚀 


<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->

<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->

<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->
Docs
<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [ ] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
