### PR TITLE
Fix auto-scroll undershooting correction location on initial page load

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -50,33 +50,47 @@ export function Events(Base) {
     #hoverOver = false;
     #enableScrollEvent = true;
     #coverHeight = 0;
-
-    #scrollTo(el) {
+    #delayScrollInterval;
+    async #scrollTo(el) {
       this.#enableScrollEvent = false;
+
+      if (document.readyState !== 'complete') {
+        clearInterval(this.#delayScrollInterval);
+        await new Promise(resolve => {
+          this.#delayScrollInterval = setInterval(() => {
+            if (document.readyState === 'complete') {
+              clearInterval(this.#delayScrollInterval);
+              resolve();
+            }
+          }, 100);
+        });
+      }
+
       el.scrollIntoView({ behavior: 'smooth' });
 
       // Determine when scrolling has stopped
       let prevTop;
-      const intervalId = setInterval(() => {
+      const completeIntervalId = setInterval(() => {
         const top = el.getBoundingClientRect().top;
         if (top === prevTop) {
-          clearInterval(intervalId);
+          console.log('clearing');
+          clearInterval(completeIntervalId);
           this.#enableScrollEvent = true;
         }
         prevTop = top;
       }, 500);
     }
 
-    #interval;
+    #delayHighlightInterval;
     async #highlight(path) {
       let delayed = false;
       if (!this.#enableScrollEvent) {
         delayed = true;
-        clearInterval(this.#interval);
+        clearInterval(this.#delayHighlightInterval);
         await new Promise(resolve => {
-          this.#interval = setInterval(() => {
+          this.#delayHighlightInterval = setInterval(() => {
             if (this.#enableScrollEvent) {
-              clearInterval(this.#interval);
+              clearInterval(this.#delayHighlightInterval);
               resolve();
             }
           }, 100);

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -1,8 +1,8 @@
-import { isMobile } from '../util/env.js';
-import { body, on } from '../util/dom.js';
-import * as dom from '../util/dom.js';
-import { removeParams } from '../router/util.js';
 import config from '../config.js';
+import { removeParams } from '../router/util.js';
+import * as dom from '../util/dom.js';
+import { body, on } from '../util/dom.js';
+import { isMobile } from '../util/env.js';
 
 /** @typedef {import('../Docsify.js').Constructor} Constructor */
 
@@ -17,13 +17,13 @@ export function Events(Base) {
 
       // If 'history', rely on the browser's scroll auto-restoration when going back or forward
       if (source !== 'history') {
-        // Scroll to ID if specified
-        if (this.route.query.id) {
-          this.#scrollIntoView(this.route.path, this.route.query.id);
-        }
         // Scroll to top if a link was clicked and auto2top is enabled
         if (source === 'navigate') {
           auto2top && this.#scroll2Top(auto2top);
+        }
+        // Scroll to ID if specified
+        if (this.route.query.id) {
+          this.#scrollIntoView(this.route.path, this.route.query.id);
         }
       }
 


### PR DESCRIPTION
## Summary

**Bug:** Navigating to an anchor link on docs with images causes the initial auto-scroll to "undershoot" the correct location. This is because the scroll location is calculated prior to the images loading, so the image heights aren't accounted for in the location calculation.

**Fix:** Replace Tweezer animation with `scrollIntoView` which adjusts for image heights.

**Additional Bug:** Auto-scroll on an initial page load does not scroll the appropriate sidebar element into view. This is because the `#highlight` function was blocked while the Tweezer animation was running.

**Fix:** Delay the `#highlight` function from running until `scrollIntoView` has finished.

## Related issue, if any:

https://github.com/docsifyjs/docsify/issues/351
https://github.com/docsifyjs/docsify/issues/559

## What kind of change does this PR introduce?

  Bugfix


## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
