### PR TITLE
Fix auto-scroll undershooting correction location on initial page load

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -53,7 +53,20 @@ export function Events(Base) {
     #enableScrollEvent = true;
     #coverHeight = 0;
 
-    #scrollTo(el, offset = 0) {
+    #delayScrollInterval;
+    async #scrollTo(el, offset = 0) {
+      if (document.readyState !== 'complete') {
+        clearInterval(this.#delayScrollInterval);
+        await new Promise(resolve => {
+          this.#delayScrollInterval = setInterval(() => {
+            if (document.readyState === 'complete') {
+              clearInterval(this.#delayScrollInterval);
+              resolve();
+            }
+          }, 100);
+        });
+      }
+
       if (this.#scroller) {
         this.#scroller.stop();
       }

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -80,7 +80,7 @@ export function Events(Base) {
           offset,
         duration: 500,
       })
-        .on('tick', v => window.scrollTo(0, path, v))
+        .on('tick', v => window.scrollTo(0, v))
         .on('done', () => {
           this.#enableScrollEvent = true;
           this.#scroller = null;

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -54,7 +54,7 @@ export function Events(Base) {
     #coverHeight = 0;
 
     #delayScrollInterval;
-    async #scrollTo(el, offset = 0) {
+    async #scrollTo(el, path, offset = 0) {
       if (document.readyState !== 'complete') {
         clearInterval(this.#delayScrollInterval);
         await new Promise(resolve => {
@@ -80,15 +80,17 @@ export function Events(Base) {
           offset,
         duration: 500,
       })
-        .on('tick', v => window.scrollTo(0, v))
+        .on('tick', v => window.scrollTo(0, path, v))
         .on('done', () => {
           this.#enableScrollEvent = true;
           this.#scroller = null;
+          el.scrollIntoView({ behavior: 'smooth' });
+          this.#highlight(path, true);
         })
         .begin();
     }
 
-    #highlight(path) {
+    #highlight(path, scroll = false) {
       if (!this.#enableScrollEvent) {
         return;
       }
@@ -120,7 +122,7 @@ export function Events(Base) {
 
       const li = this.#nav[this.#getNavKey(path, last.getAttribute('data-id'))];
 
-      if (!li || li === active) {
+      if (!li || (li === active && !scroll)) {
         return;
       }
 
@@ -206,7 +208,7 @@ export function Events(Base) {
       // Use [id='1234'] instead of #id to handle special cases such as reserved characters and pure number id
       // https://stackoverflow.com/questions/37270787/uncaught-syntaxerror-failed-to-execute-queryselector-on-document
       const section = dom.find("[id='" + id + "']");
-      section && this.#scrollTo(section, topMargin);
+      section && this.#scrollTo(section, path, topMargin);
 
       const li = this.#nav[this.#getNavKey(path, id)];
       const sidebar = dom.getNode('.sidebar');


### PR DESCRIPTION
## Summary

**Bug:** Navigating to an anchor link on docs with images causes the initial auto-scroll to "undershoot" the correct location. This is because the scroll location is calculated prior to the images loading, so the image heights aren't accounted for in the location calculation.

Fix: Wait for the document to finish loading and then scroll to the location. After scrolling to the location, call `el.scrollIntoView()` as a backup.

Additional Bug: Auto-scroll on an initial page load does not scroll the appropriate sidebar item into view. This is because `#highlight()` is blocked while the Tweezer animation is running and will not scroll the sidebar if the item is already active.

Fix: Call `#highlight()` after the Tweezer scroll animation is complete with a parameter to force the scroll.

## Related issue, if any:

https://github.com/docsifyjs/docsify/issues/351
https://github.com/docsifyjs/docsify/issues/559

## What kind of change does this PR introduce?

  Bugfix

## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
