### PR TITLE
chore: Create .gitattributes to prevent errors with Prettier in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION

<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

It is recommended by Prettier to use LF endings for all files including in Windows, and they officially recommend to set this option in .gitattributes file for consistency, and LF is the default in Prettier 2 or higher. The lack of this file bit me in another project whose build failed in Windows in GitHub Actions due to `prettier --check` failing in Windows with default LF mode.

More info: https://github.com/prettier/prettier/issues/7825#issuecomment-602171740

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?


  Build-related changes
  Repo settings


## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (pick one) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

N/A