### PR TITLE
reduce dependabot frequency from weekly to monthly, get rid of email spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,18 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: monthly
+    ignore:
+      # For all dependencies, trigger pull requests only for semver-major updates (ignore minor and patch).
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
   - package-ecosystem: 'github-actions'
     directory: '/'
     open-pull-requests-limit: 10
     schedule:
       interval: monthly
+    ignore:
+      # For all dependencies, trigger pull requests only for semver-major and semver-minor updates (ignore patch).
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: '/' # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
-      interval: 'weekly'
+      interval: monthly
   - package-ecosystem: 'github-actions'
     directory: '/'
     open-pull-requests-limit: 10


### PR DESCRIPTION


## Summary

Also ignore patch and minor bumps for dependencies, and ignore patch bumps for github actions. This will let us focus on major updates.

Docsify is a static website, there's isn't much of a security concern with checking every patch bump. We aren't making a server application for people to put across their servers, we're simply reading markdown and outputting HTML on the client, nothing very critical at all, so we don't need to spend so much time with noisy updates.

## Related issue, if any:

## What kind of change does this PR introduce?
  Build-related changes
  Repo settings

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

N/A