### PR TITLE
prevent a try catch from hiding a build error

### DIFF
--- a/build/emoji.js
+++ b/build/emoji.js
@@ -95,13 +95,9 @@ function writeEmojiJS(emojiData) {
 
 console.info('Build emoji');
 
-try {
-  const emojiData = await getEmojiData();
+const emojiData = await getEmojiData();
 
-  if (emojiData) {
-    writeEmojiPage(emojiData);
-    writeEmojiJS(emojiData);
-  }
-} catch (err) {
-  console.warn(`- Error: ${err.message}`);
+if (emojiData) {
+  writeEmojiPage(emojiData);
+  writeEmojiJS(emojiData);
 }


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

I removed the try-catch because it prevented the output from being helpful when there was an error, and made the script exit with zero instead of non-zero upon error.

## Related issue, if any:

https://github.com/docsifyjs/docsify/issues/2290

## What kind of change does this PR introduce?


  Build-related changes
  Repo settings

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

N/A