### PR TITLE
Better support for relative links (e.g. download links) for non-markdown files

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -231,6 +231,7 @@ export class Compiler {
     origin.code = highlightCodeCompiler({ renderer });
     origin.link = linkCompiler({
       renderer,
+      contentBase,
       router,
       linkTarget,
       linkRel,

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -263,5 +263,47 @@ describe('render', function () {
         `"<p><a href=\\"http://url\\" target=\\"_blank\\"  rel=\\"noopener\\" id=\\"someCssID\\">alt text</a></p>"`
       );
     });
+
+    test('relative link with md extension', async function () {
+      const output = window.marked('[alt text](test.md)');
+
+      expect(output).toMatchInlineSnapshot(
+        `"<p><a href=\\"#/test\\" >alt text</a></p>"`
+      );
+    });
+
+    test('relative link with md extension starting with "./"', async function () {
+      const output = window.marked('[alt text](./test.md)');
+
+      expect(output).toMatchInlineSnapshot(
+        `"<p><a href=\\"#/test\\" >alt text</a></p>"`
+      );
+    });
+
+    test('relative link with extension other than md', async function () {
+      const output = window.marked('[alt text](test.txt)');
+
+      expect(output).toMatchInlineSnapshot(
+        `"<p><a href=\\"http://127.0.0.1:3001/test.txt\\" >alt text</a></p>"`
+      );
+    });
+
+    test('relative link with extension other than md starting with "./"', async function () {
+      const output = window.marked('[alt text](./test.txt)');
+
+      expect(output).toMatchInlineSnapshot(
+        `"<p><a href=\\"http://127.0.0.1:3001/test.txt\\" >alt text</a></p>"`
+      );
+    });
+
+    test('absolute link with md extension', async function () {
+      const output = window.marked(
+        '[alt text](http://www.example.com/test.md)'
+      );
+
+      expect(output).toMatchInlineSnapshot(
+        `"<p><a href=\\"http://www.example.com/test.md\\" target=\\"_blank\\"  rel=\\"noopener\\">alt text</a></p>"`
+      );
+    });
   });
 });


### PR DESCRIPTION

## Summary

Currently, using relative links to non-markdown files are broken and give a 404. This PR addresses this and should fix cases such as described in https://github.com/docsifyjs/docsify/issues/1929 and others.

## Related issue, if any:

https://github.com/docsifyjs/docsify/issues/1929

## What kind of change does this PR introduce?

- Bugfix
- Refactor

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed -> Not needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No, although there has been some refactoring.

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

## Notes

Relative linked files without extension are still seen as markdown files: I don't know if this is intentional or not, but seems counterintuitive. Better would be to require to link to .md-files with an explicit mention of the .md-extension (e.g. `[test](test.md)` of `[test](./test.md)`.