### PR TITLE
fix: missing themes for root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /docs/preview.html
 /lib
 /node_modules
+/themes
 
 # exceptions
 !.gitkeep

--- a/build/mincss.js
+++ b/build/mincss.js
@@ -7,7 +7,7 @@ const files = fs.readdirSync(path.resolve('lib/themes'));
 files.forEach(file => {
   file = path.resolve('lib/themes', file);
   cssnano
-    .process(fs.readFileSync(file))
+    .process(fs.readFileSync(file), {from: undefined})
     .then(result => {
       fs.writeFileSync(file, result.css);
     })

--- a/build/mincss.js
+++ b/build/mincss.js
@@ -7,7 +7,7 @@ const files = fs.readdirSync(path.resolve('lib/themes'));
 files.forEach(file => {
   file = path.resolve('lib/themes', file);
   cssnano
-    .process(fs.readFileSync(file), {from: undefined})
+    .process(fs.readFileSync(file), { from: undefined })
     .then(result => {
       fs.writeFileSync(file, result.css);
     })

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   ],
   "scripts": {
     "build:cover": "node build/cover.js",
-    "build:css:min": "node build/mincss.js",
-    "build:css": "mkdirp lib/themes && node build/css -o lib/themes",
+    "build:css:min": "mkdirp lib/themes && node build/css -o lib/themes && node build/mincss.js",
+    "build:css": "mkdirp themes && node build/css -o themes",
     "build:emoji": "node ./build/emoji.js",
     "build:html": "node ./build/html.js",
     "build:js": "cross-env NODE_ENV=production node build/build.js",

--- a/test/e2e/gtag.test.js
+++ b/test/e2e/gtag.test.js
@@ -81,10 +81,4 @@ test.describe('Gtag Plugin Tests', () => {
     // Tests
     expect($docsify.gtag).not.toEqual('');
   });
-
-  test('data-ga attribute', async ({ page }) => {
-    pageRequestListened(page);
-
-    // TODO
-  });
 });


### PR DESCRIPTION
ref #2316, Remove duplicate `/themes` directory in root (no longer needed)

We actually need it because it's referenced in the documentation. see https://docsify.js.org/#/quickstart?id=specifying-docsify-versions

And it's uncompressed css, `lib/themes` is compressed.

I think it should be keep it.