### PR TITLE
fix: skip-to-content scroll behavior

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -31,7 +31,7 @@ export function Events(Base) {
 
       // Move focus to content
       if (query.id || source === 'navigate') {
-        this.focusContent();
+        this.#focusContent();
       }
 
       if (loadNavbar) {
@@ -139,19 +139,15 @@ export function Events(Base) {
     #enableScrollEvent = true;
     #coverHeight = 0;
 
-    #skipLink(el) {
-      el = dom.getNode(el);
+    #skipLink(elm) {
+      elm = typeof elm === 'string' ? dom.find(elm) : elm;
 
-      if (el === null || el === undefined) {
-        return;
-      }
-
-      dom.on(el, 'click', evt => {
-        const target = dom.getNode('#main');
-
+      elm?.addEventListener('click', evt => {
         evt.preventDefault();
-        target && target.focus();
-        this.#scrollTo(target);
+        dom.getNode('main')?.scrollIntoView({
+          behavior: 'smooth',
+        });
+        this.#focusContent({ preventScroll: true });
       });
     }
 
@@ -177,7 +173,7 @@ export function Events(Base) {
         .begin();
     }
 
-    focusContent() {
+    #focusContent(options = {}) {
       const { query } = this.route;
       const focusEl = query.id
         ? // Heading ID
@@ -188,7 +184,7 @@ export function Events(Base) {
           dom.find('#main');
 
       // Move focus to content area
-      focusEl && focusEl.focus();
+      focusEl && focusEl.focus(options);
     }
 
     #highlight(path) {


### PR DESCRIPTION
## Summary

Fixes an issue the new (unreleased) "Skip to Content" link that caused an immediate jump to to the content (instead scrolling) and the main content to scroll down (instead of being static) into place. 

**Example of bug** (develop branch preview w/ Chrome 123)

The incorrect behavior is the result of three separate things occurring at the same time:

1. By default, browsers will automatically scroll any offscreen element that receives focus into view. This is the correct behavior for accessibility purposes because the focused item should be in view.
2. Clicking the "Skip to Content" link places the focus on the main content area. This is the correct behavior for accessibility purposes because the focused item should be in view. However, by placing the focus on an off-screen element, the browser's default behavior (see above) causes the scroll position to jump to the content instead of smoothly scrolling to it.
3. Docsify's "smooth scroll" behavior aligns the main content container element to the top edge of the viewport.

https://github.com/docsifyjs/docsify/assets/442527/7205bd0e-598e-4e9f-97d6-11d586cad434

**Example of fix** (PR changes w/ Chrome 123)

The fix if simple thanks to modern APIs: set the `preventScroll` option to `true` when calling the browser's native `focus()` method:

https://github.com/docsifyjs/docsify/assets/442527/9509967b-40e1-469f-9cb5-e6b64e6c3f1e

## Related issue, if any:

None

## What kind of change does this PR introduce?

Bugfix

## For any code change,

N/A

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari
