### PR TITLE
fix: dev mode hot reload and add sourcemaps

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -3,8 +3,8 @@ import { promises as fs } from 'fs';
 import * as rollup from 'rollup';
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import uglify from '@rollup/plugin-terser';
 import replace from '@rollup/plugin-replace';
+import terser from '@rollup/plugin-terser';
 import chokidar from 'chokidar';
 import { relative } from './util.js';
 
@@ -54,6 +54,7 @@ async function build(opts) {
         output: opts.globalName ? { name: opts.globalName } : {},
         file: dest,
         strict: false,
+        sourcemap: opts.sourcemap,
       });
     });
 }
@@ -68,15 +69,14 @@ async function buildCore() {
     })
   );
 
-  if (isProd) {
-    promises.push(
-      build({
-        input: 'src/core/index.js',
-        output: 'docsify.min.js',
-        plugins: [uglify()],
-      })
-    );
-  }
+  promises.push(
+    build({
+      input: 'src/core/index.js',
+      output: 'docsify.min.js',
+      plugins: [terser()],
+      sourcemap: true,
+    })
+  );
 
   await Promise.all(promises);
 }
@@ -102,17 +102,16 @@ async function buildAllPlugin() {
     });
   });
 
-  if (isProd) {
-    plugins.forEach(item => {
-      promises.push(
-        build({
-          input: 'src/plugins/' + item.input,
-          output: 'plugins/' + item.name + '.min.js',
-          plugins: [uglify()],
-        })
-      );
-    });
-  }
+  plugins.forEach(item => {
+    promises.push(
+      build({
+        input: 'src/plugins/' + item.input,
+        output: 'plugins/' + item.name + '.min.js',
+        plugins: [terser()],
+        sourcemap: true,
+      })
+    );
+  });
 
   await Promise.all(promises);
 }

--- a/build/mincss.js
+++ b/build/mincss.js
@@ -9,7 +9,7 @@ const files = fs
 files.forEach(file => {
   file = path.resolve('lib/themes', file);
   cssnano
-    .process(fs.readFileSync(file))
+    .process(fs.readFileSync(file), { from: file })
     .then(result => {
       file = file.replace(/\.css$/, '.min.css');
       fs.writeFileSync(file, result.css);

--- a/server.configs.js
+++ b/server.configs.js
@@ -24,6 +24,8 @@ export const devConfig = {
   files: ['CHANGELOG.md', 'docs/**/*', 'lib/**/*'],
   port: 3000,
   rewriteRules,
+  reloadDebounce: 1000,
+  reloadOnRestart: true,
   server: {
     ...prodConfig.server,
     routes: {


### PR DESCRIPTION
## Summary

Fixes two development issues:

1. Hot reload was not working because the docs site was loading `lib/docsify.min.js` which was only updated on "production" builds. The build now generates minified and non-minified bundles for all builds.
2. Source maps are now generated for all `.min.js` files in `/lib/`. This solution is best for troubleshooting during development because source maps provide unminified source code along with accurate file and line locations on errors. Using non-minified bundles for development was previously discussed, however this approach does not provide accurate source file and line locations.

## Related issue, if any:

None

## What kind of change does this PR introduce?

Bugfix
Build-related changes

## For any code change,

N/A

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari
