### PR TITLE
fix: prevent unnecessary themeColor deprecation notice

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -47,17 +47,19 @@ export default function (vm) {
         return this.__themeColor;
       },
       set themeColor(value) {
-        this.__themeColor = value;
-        console.warn(
-          stripIndent(/* html */ `
-            $docsify.themeColor is deprecated. Use a --theme-color property in your style sheet. Example:
-            <style>
-              :root {
-                --theme-color: deeppink;
-              }
-            </style>
-          `).trim()
-        );
+        if (value) {
+          this.__themeColor = value;
+          console.warn(
+            stripIndent(`
+              $docsify.themeColor is deprecated. Use a --theme-color property in your style sheet. Example:
+              <style>
+                :root {
+                  --theme-color: deeppink;
+                }
+              </style>
+            `).trim()
+          );
+        }
       },
     },
 


### PR DESCRIPTION
## Summary

The following deprecation warning was spamming the console even when `$docsify.themeColor` was not being used: 

```
$docsify.themeColor is deprecated. Use a --theme-color property in your style sheet. Example:
<style>
  :root {
    --theme-color: deeppink;
  }
</style>
```

This console message will now only appear when $docsify.themeColor is used.

## Related issue, if any:

None

## What kind of change does this PR introduce?

Bugfix

## For any code change,

N/A

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

- [x] Chrome
- [x] Firefox
- [x] Safari
