### PR TITLE
feat: introduce a text compress for search function

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -9,6 +9,8 @@ By default, the hyperlink on the current page is recognized and the content is s
 <script>
   window.$docsify = {
     search: 'auto', // default
+    // Enable text compression to reduce the size, especially if your contents are very large.
+    largeContent: false, // default
 
     search: [
       '/',            // => /README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "lz-string": "^1.5.0",
         "medium-zoom": "^1.1.0",
         "opencollective-postinstall": "^2.0.2",
         "prismjs": "^1.29.0",
@@ -10972,6 +10973,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "*.js": "eslint --fix"
   },
   "dependencies": {
+    "lz-string": "^1.5.0",
     "medium-zoom": "^1.1.0",
     "opencollective-postinstall": "^2.0.2",
     "prismjs": "^1.29.0",

--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -14,7 +14,7 @@ const CONFIG = {
   namespace: undefined,
   pathNamespaces: undefined,
   keyBindings: ['/', 'meta+k', 'ctrl+k'],
-  largeContent: false
+  largeContent: false,
 };
 
 const install = function (hook, vm) {

--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -14,6 +14,7 @@ const CONFIG = {
   namespace: undefined,
   pathNamespaces: undefined,
   keyBindings: ['/', 'meta+k', 'ctrl+k'],
+  largeContent: false
 };
 
 const install = function (hook, vm) {
@@ -33,6 +34,7 @@ const install = function (hook, vm) {
     CONFIG.namespace = opts.namespace || CONFIG.namespace;
     CONFIG.pathNamespaces = opts.pathNamespaces || CONFIG.pathNamespaces;
     CONFIG.keyBindings = opts.keyBindings || CONFIG.keyBindings;
+    CONFIG.largeContent = opts.largeContent || CONFIG.largeContent;
   }
 
   const isAuto = CONFIG.paths === 'auto';

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -81,15 +81,17 @@ function saveData(maxAge, expireKey, indexKey, largeContent) {
   if (largeContent) {
     const compressed = LZString.compressToUTF16(JSON.stringify(INDEXS));
     localStorage.setItem(indexKey, compressed);
-  }else{
-  localStorage.setItem(indexKey, JSON.stringify(INDEXS));
+  } else {
+    localStorage.setItem(indexKey, JSON.stringify(INDEXS));
   }
 }
 
-function getData(indexKey, largeContent ) {
+function getData(indexKey, largeContent) {
   if (largeContent) {
     const compressedData = localStorage.getItem(indexKey);
-    return compressedData && JSON.parse(LZString.decompressFromUTF16(compressedData));
+    return (
+      compressedData && JSON.parse(LZString.decompressFromUTF16(compressedData))
+    );
   }
   return JSON.parse(localStorage.getItem(indexKey));
 }
@@ -292,7 +294,7 @@ export function init(config, vm) {
 
   const isExpired = localStorage.getItem(expireKey) < Date.now();
 
-  INDEXS = getData(indexKey, config.largeContent)
+  INDEXS = getData(indexKey, config.largeContent);
 
   if (isExpired) {
     INDEXS = {};
@@ -311,7 +313,8 @@ export function init(config, vm) {
     Docsify.get(vm.router.getFile(path), false, vm.config.requestHeaders).then(
       result => {
         INDEXS[path] = genIndex(path, result, vm.router, config.depth);
-        len === ++count && saveData(config.maxAge, expireKey, indexKey, config.largeContent);
+        len === ++count &&
+          saveData(config.maxAge, expireKey, indexKey, config.largeContent);
       },
     );
   });


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

The search INDEX we store in `localStorage`, and it has the limitation about 5M.
And we discussed about the `Indexed DB` and other solutions couple years ago.
Today, a sudden inspiration struck me: instead of switching the persistence layer, we can use text compression to address our retrieval needs. 
So I have found some implementations of text compression algorithms，and pick the suitable one of LZW [lz-string](https://pieroxy.net/blog/pages/lz-string/index.html) since we are more on the content/docs. 
Have a test based on our site docs, it reduces the 80% cost.
In short term, it could be a chance for users to make search still works when their docs big but not that too much.

## As-is

![Screenshot 2024-06-13 at 20 23 53](https://github.com/docsifyjs/docsify/assets/33706142/5dc5be4f-4248-4fb5-bbc0-45606f025024)

## Enable compress

![Screenshot 2024-06-13 at 20 25 46](https://github.com/docsifyjs/docsify/assets/33706142/2f284d5e-0c68-4b69-8038-e70b6d38b005)





<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->
Feature
## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->
No
## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
