### PR TITLE
Add a example of how to make a theme switch in docs/write-a-plugin.md

### DIFF
--- a/docs/write-a-plugin.md
+++ b/docs/write-a-plugin.md
@@ -197,7 +197,7 @@ hook.ready(() => {
 
 ## Examples
 
-#### Page Footer
+### Page Footer
 
 ```js
 window.$docsify = {
@@ -243,6 +243,44 @@ window.$docsify = {
         );
       });
     },
+  ],
+};
+```
+
+### Theme Swich
+
+It wiil add a theme switch to the after the sidebar and auto add the dark class to the body element, so it you can control the theme by css `body.dark`
+
+```js
+window.$docsify = {
+  plugins: [
+        function (hook, vm) {
+          // Darkmode
+          let light = "☀️"; // light logo
+          let dark = "🌑"; // dark logo
+          let switchID = "themeSwitch";
+          let rootNode = document.querySelector("body");  // add dark class to body
+          let autodark = window.matchMedia("(prefers-color-scheme: dark)"); // check system setting
+          var syncTheme = (switchNode) => {
+            switchNode.innerHTML === light
+              ? rootNode.classList.remove("dark")
+              : rootNode.classList.add("dark");
+          };
+          hook.mounted(function () {
+            let theme = autodark.matches ? dark : light;
+            let botton = `<div style="text-align: center"><span id=${switchID}>${theme}</span></div>`;
+            let insertArea = document.querySelector("h1.app-name");
+            insertArea.insertAdjacentHTML("afterend", botton);
+            let element = document.getElementById(switchID);
+            syncTheme(element);
+
+            element.addEventListener("click", () => {
+              let isLight = element.innerHTML === light;
+              element.innerHTML = isLight ? dark : light;
+              syncTheme(element);
+            });
+          });
+        },
   ],
 };
 ```


### PR DESCRIPTION
## Summary

Add a example of how to make a theme switch in docs/write-a-plugin.md, this switch can switch self and auto add dark class to the body

also the light and darkmode's logo can be modified. and the example demo is https://hqshi.cn

darkmode

<img width="1068" alt="image" src="https://github.com/docsifyjs/docsify/assets/34450149/bf907c90-3f92-4947-8c21-9a97c9789290">

ligthmode

<img width="1060" alt="image" src="https://github.com/docsifyjs/docsify/assets/34450149/5452cef8-aa32-4a69-9c92-07de6febc7f1">


## What kind of change does this PR introduce?

a improvement of Docs

## For any code change,

no any code changed

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

of couse not

## Tested in the following browsers:

- [x] Chrome
- [x] Safari(ios)
- [x] Edge(Android)
