### PR TITLE
refactor: rewrite getAndRemoveConfig(str) function

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -30,27 +30,27 @@ const compileMedia = {
       url,
     };
   },
-  iframe(url, title) {
+  iframe(url, props) {
     return {
       html: `<iframe src="${url}" ${
-        title || 'width=100% height=400'
+        props || 'width=100% height=400'
       }></iframe>`,
     };
   },
-  video(url, title) {
+  video(url, props) {
     return {
-      html: `<video src="${url}" ${title || 'controls'}>Not Support</video>`,
+      html: `<video src="${url}" ${props || 'controls'}>Not Support</video>`,
     };
   },
-  audio(url, title) {
+  audio(url, props) {
     return {
-      html: `<audio src="${url}" ${title || 'controls'}>Not Support</audio>`,
+      html: `<audio src="${url}" ${props || 'controls'}>Not Support</audio>`,
     };
   },
-  code(url, title) {
+  code(url, props) {
     let lang = url.match(/\.(\w+)$/);
 
-    lang = title || (lang && lang[1]);
+    lang = props || (lang && lang[1]);
     if (lang === 'md') {
       lang = 'markdown';
     }
@@ -143,9 +143,9 @@ export class Compiler {
    * @return {type} Return value description.
    */
   compileEmbed(href, title) {
-    const { str, config } = getAndRemoveConfig(title);
+    const { config } = getAndRemoveConfig(title);
     let embed;
-    title = str;
+    const appenedProps = config.type_appened_props;
 
     if (config.include) {
       if (!isAbsolutePath(href)) {
@@ -158,7 +158,7 @@ export class Compiler {
 
       let media;
       if (config.type && (media = compileMedia[config.type])) {
-        embed = media.call(this, href, title);
+        embed = media.call(this, href, appenedProps);
         embed.type = config.type;
       } else {
         let type = 'code';
@@ -174,7 +174,7 @@ export class Compiler {
           type = 'audio';
         }
 
-        embed = compileMedia[type].call(this, href, title);
+        embed = compileMedia[type].call(this, href, appenedProps);
         embed.type = type;
       }
 

--- a/src/core/render/compiler/image.js
+++ b/src/core/render/compiler/image.js
@@ -27,7 +27,11 @@ export const imageCompiler = ({ renderer, contentBase, router }) =>
     }
 
     if (config.class) {
-      attrs.push(`class="${config.class}"`);
+      let classes = config.class;
+      if (config.class_appened_props) {
+        classes = `${config.config.class} ${config.class_appened_props}`;
+      }
+      attrs.push(`class="${classes}"`);
     }
 
     if (config.id) {

--- a/src/core/render/compiler/image.js
+++ b/src/core/render/compiler/image.js
@@ -29,7 +29,7 @@ export const imageCompiler = ({ renderer, contentBase, router }) =>
     if (config.class) {
       let classes = config.class;
       if (config.class_appened_props) {
-        classes = `${config.config.class} ${config.class_appened_props}`;
+        classes = `${config.class} ${config.class_appened_props}`;
       }
       attrs.push(`class="${classes}"`);
     }

--- a/src/core/render/compiler/link.js
+++ b/src/core/render/compiler/link.js
@@ -55,7 +55,7 @@ export const linkCompiler = ({
     if (config.class) {
       let classes = config.class;
       if (config.class_appened_props) {
-        classes = `${config.config.class} ${config.class_appened_props}`;
+        classes = `${config.class} ${config.class_appened_props}`;
       }
       attrs.push(`class="${classes}"`);
     }

--- a/src/core/render/compiler/link.js
+++ b/src/core/render/compiler/link.js
@@ -10,13 +10,12 @@ export const linkCompiler = ({
 }) =>
   (renderer.link = (href, title = '', text) => {
     const attrs = [];
-    const { str, config } = getAndRemoveConfig(title);
+    const { config } = getAndRemoveConfig(title);
     linkTarget = config.target || linkTarget;
     linkRel =
       linkTarget === '_blank'
         ? compilerClass.config.externalLinkRel || 'noopener'
         : '';
-    title = str;
 
     if (
       !isAbsolutePath(href) &&
@@ -53,15 +52,19 @@ export const linkCompiler = ({
     }
 
     if (config.class) {
-      attrs.push(`class="${config.class}"`);
+      let classes = config.class;
+      if (config.class_appened_props) {
+        classes = `${config.config.class} ${config.class_appened_props}`;
+      }
+      attrs.push(`class="${classes}"`);
     }
 
     if (config.id) {
       attrs.push(`id="${config.id}"`);
     }
 
-    if (title) {
-      attrs.push(`title="${title}"`);
+    if (config.ignore_appened_props) {
+      attrs.push(`title="${config.ignore_appened_props}"`);
     }
 
     return /* html */ `<a href="${href}" ${attrs.join(' ')}>${text}</a>`;

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -6,17 +6,28 @@
  * An example of this is ':include :type=code :fragment=demo' is taken and
  * then converted to:
  *
+ * Specially the exitra values following a key, such as `:propKey=propVal additinalProp1 additinalProp2`
+ * or `:propKey propVal additinalProp1 additinalProp2`, those additional values will be appended to the key with `_appened_props` suffix
+ * as the additional props for the key.
+ * the example above, its result will be `{ propKey: propVal, propKey_appened_props: 'additinalProp1 additinalProp2' }`
+ *
  * ```
+ * [](_media/example.html ':include :type=code text :fragment=demo :class=foo bar bee')
  * {
  *  include: '',
  *  type: 'code',
- *  fragment: 'demo'
+ *  type_appened_props: 'text',
+ *  fragment: 'demo',
+ *  class: 'foo',
+ *  class_appened_props: 'bar bee'
  * }
  * ```
  *
+ * Any invalid config keys will be logged warning to the console intead of swallow them silently.
+ *
  * @param {string}   str   The string to parse.
  *
- * @return {{str: string, config: object}} The original string formatted, and parsed object, { str, config }.
+ * @return {{str: string, config: object}} The string after parsed the config, and the parsed configs.
  */
 export function getAndRemoveConfig(str = '') {
   const config = {};
@@ -25,20 +36,173 @@ export function getAndRemoveConfig(str = '') {
     str = str
       .replace(/^('|")/, '')
       .replace(/('|")$/, '')
-      .replace(/(?:^|\s):([\w-]+:?)=?([\w-%]+)?/g, (m, key, value) => {
-        if (key.indexOf(':') === -1) {
-          config[key] = (value && value.replace(/&quot;/g, '')) || true;
-          return '';
-        }
-
-        return m;
-      })
       .trim();
+    return lexer(str);
   }
 
   return { str, config };
 }
 
+const lexer = function (str) {
+  const FLAG = ':';
+  const EQUIL = '=';
+  const tokens = str.split('');
+  let cur = 0;
+  const configs = {};
+  const invalidConfigKeys = [];
+
+  const scanner = function (token) {
+    if (isAtEnd()) {return;}
+
+    if (isBlank(token)) {
+      return;
+    }
+    if (token !== FLAG) {
+      return;
+    }
+
+    let curToken = '';
+    let start = cur - 1;
+
+    // eat start '/" if it exists
+    if (tokens[start - 1] && tokens[start - 1].match(/['"]/)) {
+      start--;
+    }
+
+    while (!isBlank(peek()) && !(peek() === EQUIL) && !peek().match(/['"]/)) {
+      curToken += advance();
+    }
+
+    let match = true;
+    // Check for the currentToken and process it with our keywords
+    switch (curToken) {
+      // customise ID for headings or #id
+      case 'id':
+        configs.id = findValuePair();
+        break;
+      // customise class for headings
+      case 'type':
+        configs.type = findValuePair();
+        findAdditionalPropsIfExist('type');
+        break;
+      // ignore to compile link, e.g. ':ignore' , ':ignore title'
+      case 'ignore':
+        configs.ignore = true;
+        findAdditionalPropsIfExist('ignore');
+        break;
+      // include
+      case 'include':
+        configs.include = true;
+        break;
+      // Embedded code fragments e.g. :fragment=demo'
+      case 'fragment':
+        configs.fragment = findValuePair();
+        break;
+      // Disable link :disabled
+      case 'disabled':
+        configs.disabled = true;
+        break;
+      // Link target config, e.g. target=_blank
+      case 'target':
+        configs.target = findValuePair();
+        break;
+      // Image size config, e.g. size=100, size=WIDTHxHEIGHT
+      case 'size':
+        configs.size = findValuePair();
+        break;
+      case 'class':
+        configs.class = findValuePair();
+        findAdditionalPropsIfExist('class');
+        break;
+      case 'no-zoom':
+        configs['no-zoom'] = true;
+        break;
+      default:
+        // Although it start with FLAG (:), it is an invalid config token for docsify
+        if (curToken.endsWith(FLAG)) {
+          // okay, suppose it should be a emoji, skip it to make all happy
+        } else {
+          invalidConfigKeys.push(FLAG + curToken);
+        }
+        match = false;
+    }
+
+    if (match) {
+      for (let i = start; i < cur; i++) {
+        tokens[i] = '';
+      }
+
+      // eat the end '/" if it exists
+      if (peek().match(/['"]/)) {
+        tokens[cur] = '';
+        advance();
+      }
+      match = false;
+    }
+  };
+
+  const isAtEnd = function () {
+    return cur >= tokens.length;
+  };
+
+  const findValuePair = function () {
+    if (peek() === EQUIL) {
+      // Skip the EQUIL
+      advance();
+      let val = '';
+      // Find the value until the end of the string or next FLAG
+      while (!isBlank(peek()) && !peek().match(/['"]/)) {
+        val += advance();
+      }
+      return val.trim();
+    }
+
+    return '';
+  };
+
+  const findAdditionalPropsIfExist = function (configKey) {
+    while (isBlank(peek())) {
+      advance();
+      if (isAtEnd()) {
+        break;
+      }
+    }
+
+    let val = '';
+    while (!peek().match(/['"]/) && peek() !== FLAG && !isAtEnd()) {
+      val += advance();
+    }
+
+    val && (configs[configKey + '_appened_props'] = val.trimEnd());
+  };
+
+  const peek = function () {
+    if (isAtEnd()) {return '';}
+    return tokens[cur];
+  };
+
+  const advance = function () {
+    return tokens[cur++];
+  };
+
+  const isBlank = str => {
+    return !str || /^\s*$/.test(str);
+  };
+
+  while (!isAtEnd()) {
+    scanner(advance());
+  }
+
+  if (invalidConfigKeys.length > 0) {
+    const msg = invalidConfigKeys.join(', ');
+    console.warn(
+      `May find docsify doesn't support config keys: [${msg}], please recheck it.`,
+    );
+  }
+
+  const content = tokens.join('').trim();
+  return { str: content, config: configs };
+};
 /**
  * Remove the <a> tag from sidebar when the header with link, details see issue 1069
  * @param {string}   str   The string to deal with.

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -69,19 +69,19 @@ const lexer = function (str) {
     if (startConfigsStringIndex === -1) {
       const possibleStartQuoteIndex = findPossiableStartQuote(start);
       const possibleStartQuote = tokens[possibleStartQuoteIndex];
-      // Can not find the start quote, it means it is not a valid config scope, e.g.  `[example](_mediea/xx.md  :include )`.
+
       if (possibleStartQuoteIndex !== -1) {
-        // Find the close quote
         const possibleEndQuoteIndex = findPossiableEndQuote(
           start,
           possibleStartQuote,
         );
-        // Can not find a close quote, e.g.  `[example](_mediea/xx.md  ":include )`.
-        if (possibleEndQuoteIndex === -1) {
+
+        if (!possibleStartQuote) {
           return;
         }
-        // Can not find a matched close quote but a wired string, e.g.  `[example](_mediea/xx.md  ":include' )`.
-        if (possibleStartQuote !== tokens[possibleEndQuoteIndex]) {
+
+        const possibleEndQuote = tokens[possibleEndQuoteIndex];
+        if (possibleStartQuote !== possibleEndQuote) {
           return;
         }
         endConfigsStringIndex = possibleEndQuoteIndex;
@@ -101,18 +101,17 @@ const lexer = function (str) {
     }
 
     let match = true;
-    // Check for the currentToken and process it with our keywords.
+
     switch (curToken) {
-      // Customise ID for headings or #id.
-      // Note: when user wrapper the id value like this :id="something" in heading, it will bring the excaped quotes, we should remove it.
+      // Customise ID for headings  #Docsify :id=heading .
       case 'id':
-        configs.id = findValuePair().replace(/&quot;/g, '');
+        configs.id = findValuePair();
         break;
       case 'type':
         configs.type = findValuePair();
         findAdditionalPropsIfExist('type');
         break;
-      // Ignore to compile link, e.g. ':ignore' , ':ignore title'.
+      // Ignore to compile link, e.g. :ignore , :ignore title.
       case 'ignore':
         configs.ignore = true;
         findAdditionalPropsIfExist('ignore');
@@ -145,8 +144,8 @@ const lexer = function (str) {
         configs['no-zoom'] = true;
         break;
       default:
+        // Although it start with FLAG (:), it is an invalid config token for docsify.
         match = false;
-      // Although it start with FLAG (:), it is an invalid config token for docsify.
     }
 
     if (match) {
@@ -170,7 +169,7 @@ const lexer = function (str) {
         val += advance();
       }
 
-      return val.trim();
+      return val.trim().replace(/&quot;/g, '');
     }
 
     return '';

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -52,7 +52,9 @@ const lexer = function (str) {
   const invalidConfigKeys = [];
 
   const scanner = function (token) {
-    if (isAtEnd()) {return;}
+    if (isAtEnd()) {
+      return;
+    }
 
     if (isBlank(token)) {
       return;
@@ -177,7 +179,9 @@ const lexer = function (str) {
   };
 
   const peek = function () {
-    if (isAtEnd()) {return '';}
+    if (isAtEnd()) {
+      return '';
+    }
     return tokens[cur];
   };
 

--- a/src/core/render/utils.js
+++ b/src/core/render/utils.js
@@ -6,7 +6,7 @@
  * An example of this is ':include :type=code :fragment=demo' is taken and
  * then converted to:
  *
- * Specially the exitra values following a key, such as `:propKey=propVal additinalProp1 additinalProp2`
+ * Specially the extra values following a key, such as `:propKey=propVal additinalProp1 additinalProp2`
  * or `:propKey propVal additinalProp1 additinalProp2`, those additional values will be appended to the key with `_appened_props` suffix
  * as the additional props for the key.
  * the example above, its result will be `{ propKey: propVal, propKey_appened_props: 'additinalProp1 additinalProp2' }`
@@ -66,7 +66,7 @@ const lexer = function (str) {
     let curToken = '';
     let start = cur - 1;
 
-    // eat start '/" if it exists
+    // Eat start '/" if it exists
     if (tokens[start - 1] && tokens[start - 1].match(/['"]/)) {
       start--;
     }
@@ -76,27 +76,26 @@ const lexer = function (str) {
     }
 
     let match = true;
-    // Check for the currentToken and process it with our keywords
+    // Check for the currentToken and process it with our keywords.
     switch (curToken) {
-      // customise ID for headings or #id
+      // Customise ID for headings or #id.
       case 'id':
         configs.id = findValuePair();
         break;
-      // customise class for headings
       case 'type':
         configs.type = findValuePair();
         findAdditionalPropsIfExist('type');
         break;
-      // ignore to compile link, e.g. ':ignore' , ':ignore title'
+      // Ignore to compile link, e.g. ':ignore' , ':ignore title'.
       case 'ignore':
         configs.ignore = true;
         findAdditionalPropsIfExist('ignore');
         break;
-      // include
+      // Include
       case 'include':
         configs.include = true;
         break;
-      // Embedded code fragments e.g. :fragment=demo'
+      // Embedded code fragments e.g. :fragment=demo'.
       case 'fragment':
         configs.fragment = findValuePair();
         break;
@@ -104,11 +103,11 @@ const lexer = function (str) {
       case 'disabled':
         configs.disabled = true;
         break;
-      // Link target config, e.g. target=_blank
+      // Link target config, e.g. target=_blank.
       case 'target':
         configs.target = findValuePair();
         break;
-      // Image size config, e.g. size=100, size=WIDTHxHEIGHT
+      // Image size config, e.g. size=100, size=WIDTHxHEIGHT.
       case 'size':
         configs.size = findValuePair();
         break;
@@ -120,9 +119,9 @@ const lexer = function (str) {
         configs['no-zoom'] = true;
         break;
       default:
-        // Although it start with FLAG (:), it is an invalid config token for docsify
+        // Although it start with FLAG (:), it is an invalid config token for docsify.
         if (curToken.endsWith(FLAG)) {
-          // okay, suppose it should be a emoji, skip it to make all happy
+          // Okay, suppose it should be an emoji, skip to warn it to make all happy.
         } else {
           invalidConfigKeys.push(FLAG + curToken);
         }

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -153,14 +153,6 @@ describe('render', function () {
       );
     });
 
-    test('compatibility case when id in heading with quoto', async function () {
-      const output = window.marked('# MyHeader :id="myQuotedId"');
-
-      expect(output).toMatchInlineSnapshot(
-        '"<h1 id="myquotedid" tabindex="-1"><a href="#/?id=myquotedid" data-id="myquotedid" class="anchor"><span>MyHeader</span></a></h1>"',
-      );
-    });
-
     test('no-zoom', async function () {
       const output = window.marked("![alt text](http://imageUrl ':no-zoom')");
 

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -125,7 +125,7 @@ describe('render', function () {
       );
     });
 
-    test('multi class and losse quotes', async function () {
+    test('multi class and loose quotes', async function () {
       const output = window.marked(
         "![alt text](http://imageUrl ' target=_self :class=someCssClass someCssClassB ')",
       );

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -271,11 +271,11 @@ describe('render', function () {
 
     test('class', async function () {
       const output = window.marked(
-        "[alt text](http://url ':class=someCssClass')",
+        "[alt text](http://url ':class=someCssClass someCssClassB')",
       );
 
       expect(output).toMatchInlineSnapshot(
-        '"<p><a href="http://url" target="_blank"  rel="noopener" class="someCssClass">alt text</a></p>"',
+        '"<p><a href="http://url" target="_blank"  rel="noopener" class="someCssClass someCssClassB">alt text</a></p>"',
       );
     });
 

--- a/test/integration/render.test.js
+++ b/test/integration/render.test.js
@@ -125,6 +125,16 @@ describe('render', function () {
       );
     });
 
+    test('multi class and losse quotes', async function () {
+      const output = window.marked(
+        "![alt text](http://imageUrl ' target=_self :class=someCssClass someCssClassB ')",
+      );
+
+      expect(output).toMatchInlineSnapshot(
+        '"<p><img src="http://imageUrl" data-origin="http://imageUrl" alt="alt text" title="target=_self" class="someCssClass someCssClassB" /></p>"',
+      );
+    });
+
     test('id', async function () {
       const output = window.marked(
         "![alt text](http://imageUrl ':id=someCssID')",
@@ -132,6 +142,22 @@ describe('render', function () {
 
       expect(output).toMatchInlineSnapshot(
         '"<p><img src="http://imageUrl" data-origin="http://imageUrl" alt="alt text" id="someCssID" /></p>"',
+      );
+    });
+
+    test('id in heading', async function () {
+      const output = window.marked('# MyHeader :id=myNewId');
+
+      expect(output).toMatchInlineSnapshot(
+        '"<h1 id="mynewid" tabindex="-1"><a href="#/?id=mynewid" data-id="mynewid" class="anchor"><span>MyHeader</span></a></h1>"',
+      );
+    });
+
+    test('compatibility case when id in heading with quoto', async function () {
+      const output = window.marked('# MyHeader :id="myQuotedId"');
+
+      expect(output).toMatchInlineSnapshot(
+        '"<h1 id="myquotedid" tabindex="-1"><a href="#/?id=myquotedid" data-id="myquotedid" class="anchor"><span>MyHeader</span></a></h1>"',
       );
     });
 

--- a/test/unit/render-util.test.js
+++ b/test/unit/render-util.test.js
@@ -62,7 +62,16 @@ describe('core/render/utils', () => {
   // getAndRemoveConfig()
   // ---------------------------------------------------------------------------
   describe('getAndRemoveConfig()', () => {
-    test('parse simple class config', () => {
+    test('parse a headling config which is no leading quoto', () => {
+      const result = getAndRemoveConfig('Test :id=myTitle');
+
+      expect(result).toMatchObject({
+        config: { id: 'myTitle' },
+        str: 'Test',
+      });
+    });
+
+    test('parse simple classes config', () => {
       const result = getAndRemoveConfig(
         "[filename](_media/example.md ':class=foo bar')",
       );
@@ -82,7 +91,7 @@ describe('core/render/utils', () => {
       });
     });
 
-    test('parse simple config with emoji no config', () => {
+    test('parse simple config with emoji and no config', () => {
       const result = getAndRemoveConfig(
         'I use the :emoji: but it should be fine with :code=js',
       );
@@ -93,7 +102,7 @@ describe('core/render/utils', () => {
       });
     });
 
-    test('parse config with invalid arguments', () => {
+    test('parse config with invalid data attributes but we can swallow them', () => {
       const result = getAndRemoveConfig(
         "[filename](_media/example.md ':include :class=myClz myClz2 myClz3 :invalid=bar :invalid2 test')",
       );
@@ -104,12 +113,11 @@ describe('core/render/utils', () => {
           class: 'myClz',
           class_appened_props: 'myClz2 myClz3',
         },
-        // It looks weird since it quotes the invalid configs, and we don't want to swallow them.
-        str: "[filename](_media/example.md  :invalid=bar :invalid2 test')",
+        str: '[filename](_media/example.md )',
       });
     });
 
-    test('parse config with double quotes', () => {
+    test('parse config with double quotes configs string', () => {
       const result = getAndRemoveConfig(
         '[filename](_media/example.md ":type=code js :include")',
       );
@@ -124,9 +132,40 @@ describe('core/render/utils', () => {
       });
     });
 
+    test('parse config with double quotes and loose leading/ending quotos', () => {
+      const result = getAndRemoveConfig(
+        '[filename](_media/example.md "   :target=_self        :type=code js :include            ")',
+      );
+
+      expect(result).toMatchObject({
+        config: {
+          include: true,
+          type: 'code',
+          type_appened_props: 'js',
+          target: '_self',
+        },
+        str: '[filename](_media/example.md )',
+      });
+    });
+
+    test('parse config with some custom appened configs which we could use in further', () => {
+      const result = getAndRemoveConfig(
+        '[filename](_media/example.md " :type=code lang=js highlight=false :include  ")',
+      );
+
+      expect(result).toMatchObject({
+        config: {
+          include: true,
+          type: 'code',
+          type_appened_props: 'lang=js highlight=false',
+        },
+        str: '[filename](_media/example.md )',
+      });
+    });
+
     test('parse config with naughty complex string', () => {
       const result = getAndRemoveConfig(
-        "It should work :dog: and the ::dog2:: and the ::dog3::dog4::  :id=myTitle :type=code js :include'",
+        "It should work :dog: and the ::dog2:: and the ::dog3::dog4::  '    :id=myTitle :type=code js :include'",
       );
 
       expect(result).toMatchObject({
@@ -137,6 +176,23 @@ describe('core/render/utils', () => {
           include: true,
         },
         str: 'It should work :dog: and the ::dog2:: and the ::dog3::dog4::',
+      });
+    });
+
+    test('parse config with multi config arguments', () => {
+      const result = getAndRemoveConfig(
+        "[filename](_media/example.md ':include :class=myClz myClz2 myClz3 :target=_blank')",
+      );
+
+      expect(result).toMatchObject({
+        config: {
+          include: true,
+          class: 'myClz',
+          class_appened_props: 'myClz2 myClz3',
+          target: '_blank',
+        },
+        // It looks weird since it quotes the invalid configs, and we don't want to swallow them.
+        str: '[filename](_media/example.md )',
       });
     });
   });

--- a/test/unit/render-util.test.js
+++ b/test/unit/render-util.test.js
@@ -191,7 +191,6 @@ describe('core/render/utils', () => {
           class_appened_props: 'myClz2 myClz3',
           target: '_blank',
         },
-        // It looks weird since it quotes the invalid configs, and we don't want to swallow them.
         str: '[filename](_media/example.md )',
       });
     });


### PR DESCRIPTION

<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Reactor `getAndRemoveConfig(str)` function to a generic Lexer instead of a complex regex. 
Correct current behavior and indicate docsify needs to resolve valid config keys. Warning invalid configs also.

Remove to use a tricky returned `title` as config options.
Instead, new `KEY_appened_props` introduced. 

It will let the config parse as `:KEY=VALUE append_props...`, each config processor can handle its own logic 
for the `Value` and `append_props`. e.g.

> `:class=classA classB classC :include`
The classA assigns to `class`=`classA`, the rest of `classB classC` add to `class_appened_props`.

> config
```
{
  class: "classA",
  class_appened_props: "classB classC",
  include: true
}
```

Which can support `multi values` configs of one key such as #2471 .

<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

 

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->
Refactor
## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
