### PR TITLE
fix: auto header config heading generate func

### DIFF
--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -74,17 +74,16 @@ export class Compiler {
       this.linkTarget === '_blank' ? config.externalLinkRel || 'noopener' : '';
     this.contentBase = router.getBasePath();
 
-    const renderer = this._initRenderer();
-    this.heading = renderer.heading;
+    this.renderer = this._initRenderer();
     let compile;
     const mdConf = config.markdown || {};
 
     if (isFn(mdConf)) {
-      compile = mdConf(marked, renderer);
+      compile = mdConf(marked, this.renderer);
     } else {
       marked.setOptions(
         Object.assign(mdConf, {
-          renderer: Object.assign(renderer, mdConf.renderer),
+          renderer: Object.assign(this.renderer, mdConf.renderer),
         }),
       );
       compile = marked;
@@ -318,12 +317,21 @@ export class Compiler {
     return treeTpl(tree);
   }
 
+  /**
+   * Compile the text to generate HTML heading element based on the level
+   * @param {*} text Text content, for now it is only from the _sidebar.md file
+   * @param {*} level Type of heading (h<level> tag), for now it is always 1
+   * @returns
+   */
   header(text, level) {
-    return this.heading(text, level);
-  }
-
-  article(text) {
-    return this.compile(text);
+    const tokenHeading = {
+      type: 'heading',
+      raw: text,
+      depth: level,
+      text: text,
+      tokens: [{ type: 'text', raw: text, text: text }],
+    };
+    return this.renderer.heading(tokenHeading);
   }
 
   /**

--- a/test/e2e/sidebar.test.js
+++ b/test/e2e/sidebar.test.js
@@ -94,13 +94,6 @@ test.describe('Configuration: autoHeader', () => {
 
     await page.click('a[href="#/quickstart"]');
     expect(page.url()).toMatch(/\/quickstart$/);
-    // const element = page.locator('#main');
-    // expect(await element.innerText()).toContain(
-    //   'In the main content there is no h1',
-    // );
-    // expect(await element.innerText()).toContain(
-    //   'the content of quickstart space',
-    // );
     // not heading
     await expect(page.locator('#quickstart')).toBeHidden();
   });

--- a/test/e2e/sidebar.test.js
+++ b/test/e2e/sidebar.test.js
@@ -69,3 +69,96 @@ test.describe('Sidebar Tests', () => {
     expect(page.url()).toMatch(/\/test%3Efoo$/);
   });
 });
+
+test.describe('Configuration: autoHeader', () => {
+  test('autoHeader=false', async ({ page }) => {
+    const docsifyInitConfig = {
+      config: {
+        loadSidebar: '_sidebar.md',
+        autoHeader: false,
+      },
+      markdown: {
+        sidebar: `
+            - [QuickStartAutoHeader](quickstart.md)
+          `,
+      },
+      routes: {
+        '/quickstart.md': `
+            the content of quickstart space
+            ## In the main content there is no h1
+          `,
+      },
+    };
+
+    await docsifyInit(docsifyInitConfig);
+
+    await page.click('a[href="#/quickstart"]');
+    expect(page.url()).toMatch(/\/quickstart$/);
+    // const element = page.locator('#main');
+    // expect(await element.innerText()).toContain(
+    //   'In the main content there is no h1',
+    // );
+    // expect(await element.innerText()).toContain(
+    //   'the content of quickstart space',
+    // );
+    // not heading
+    await expect(page.locator('#quickstart')).toBeHidden();
+  });
+
+  test('autoHeader=true', async ({ page }) => {
+    const docsifyInitConfig = {
+      config: {
+        loadSidebar: '_sidebar.md',
+        autoHeader: true,
+      },
+      markdown: {
+        sidebar: `
+            - [QuickStartAutoHeader](quickstart.md )
+          `,
+      },
+      routes: {
+        '/quickstart.md': `
+            the content of quickstart space
+            ## In the main content there is no h1
+          `,
+      },
+    };
+
+    await docsifyInit(docsifyInitConfig);
+
+    await page.click('a[href="#/quickstart"]');
+    expect(page.url()).toMatch(/\/quickstart$/);
+
+    // auto generate default heading id
+    const autoHeader = page.locator('#quickstartautoheader');
+    expect(await autoHeader.innerText()).toContain('QuickStartAutoHeader');
+  });
+
+  test('autoHeader=true and custom headingId', async ({ page }) => {
+    const docsifyInitConfig = {
+      config: {
+        loadSidebar: '_sidebar.md',
+        autoHeader: true,
+      },
+      markdown: {
+        sidebar: `
+            - [QuickStartAutoHeader](quickstart.md ":id=quickstartId")
+          `,
+      },
+      routes: {
+        '/quickstart.md': `
+            the content of quickstart space
+            ## In the main content there is no h1
+          `,
+      },
+    };
+
+    await docsifyInit(docsifyInitConfig);
+
+    await page.click('a[href="#/quickstart"]');
+    expect(page.url()).toMatch(/\/quickstart$/);
+    // auto generate custom heading id
+    const autoHeader = page.locator('#quickstartId');
+    expect(await autoHeader.innerText()).toContain('QuickStartAutoHeader');
+  });
+});


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

For docsify `autoHeader` config, there is a separately call to renderer of marked.
Fix the autoHeader's heading marked adaption function and add test case for this.

<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->

Bugfix
## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
