### PR TITLE
docs: correct docs wrong link for adding pages

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ After the `init` is complete, you can see the file list in the `./docs` subdirec
 - `README.md` as the home page
 - `.nojekyll` prevents GitHub Pages from ignoring files that begin with an underscore
 
-You can easily update the documentation in `./docs/README.md`, of course you can add [more pages](more-pages.md).
+You can easily update the documentation in `./docs/README.md`, of course you can add [more pages](adding-pages.md).
 
 ## Preview your site
 


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Mino changes since we now have `adding-pages` instead.

I find this when review the changes we made recently.
And I know we will have next around to review docs also, just fix it btw. :)

<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->
Docs
## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
