### PR TITLE
fix: Prevent initial unnecessary IntersectionObserver callback execution

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -99,11 +99,16 @@ export function Events(Base) {
           if (headingsInView.size === 1) {
             activeHeading = headingsInView.values().next().value;
           } else if (headingsInView.size > 1) {
-            activeHeading = Array.from(headingsInView).reduce((closest, current) => {
-              return !closest || (closest.compareDocumentPosition(current) & Node.DOCUMENT_POSITION_FOLLOWING)
-                ? current
-                : closest;
-            }, null);
+            activeHeading = Array.from(headingsInView).reduce(
+              (closest, current) => {
+                return !closest ||
+                  closest.compareDocumentPosition(current) &
+                    Node.DOCUMENT_POSITION_FOLLOWING
+                  ? current
+                  : closest;
+              },
+              null,
+            );
           }
 
           if (activeHeading) {

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -95,10 +95,14 @@ export function Events(Base) {
             headingsInView[op](entry.target);
           }
 
-          let activeHeading = undefined;
+          let activeHeading;
           if (headingsInView.size === 1) {
+            // Get first and only item in set.
+            // May be undefined if no headings are in view.
             activeHeading = headingsInView.values().next().value;
           } else if (headingsInView.size > 1) {
+            // Find the closest heading to the top of the viewport
+            // Reduce over the Set of headings currently in view (headingsInView) to determine the closest heading.
             activeHeading = Array.from(headingsInView).reduce(
               (closest, current) => {
                 return !closest ||

--- a/src/core/render/compiler.js
+++ b/src/core/render/compiler.js
@@ -181,7 +181,7 @@ export class Compiler {
   }
 
   /**
-   * Compile sidebar, it uses  _sidebar.md ( or specific file) or the content's headings toc to render sidebar.
+   * Compile sidebar, it uses _sidebar.md (or specific file) or the content's headings toc to render sidebar.
    * @param {String} text Text content from the sidebar file, maybe empty
    * @param {Number} level Type of heading (h<level> tag)
    * @returns {String} Sidebar element


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

- Added a flag (`isInitialLoad`) to skip the first callback execution of the IntersectionObserver on page load.

<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

## Related issue, if any:

Fix #2504
Fix #2509

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

Bugfix

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
