### PR TITLE
feat: Support dark mode for zoom-image plugin

### DIFF
--- a/src/plugins/zoom-image.js
+++ b/src/plugins/zoom-image.js
@@ -10,13 +10,17 @@ function install(hook) {
       ),
     );
 
+    Docsify.dom.style(
+      `.medium-zoom-image--opened,.medium-zoom-overlay{z-index:999}`,
+    );
+
     elms = elms.filter(elm => !elm.matches('a img'));
 
     if (zoom) {
       zoom.detach();
     }
 
-    zoom = mediumZoom(elms);
+    zoom = mediumZoom(elms, { background: 'var(--color-bg)' });
   });
 }
 


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

- Support dark mode for zoom-image plugin.
- Add z-index, Fix: 

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/8713227c-04d9-4c93-b1d7-f31ac169dd6f" />

<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

## Related issue, if any:

Fix #2508

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

Feature

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
