### PR TITLE
fix: parse heading error

### DIFF
--- a/src/plugins/search/markdown-to-txt.js
+++ b/src/plugins/search/markdown-to-txt.js
@@ -59,7 +59,7 @@ const markdownToTxtRenderer = {
   },
 
   heading({ tokens }) {
-    return this.parser?.parse(tokens) || '';
+    return this.parser?.parseInline(tokens) || '';
   },
 
   hr() {


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

see https://github.com/markedjs/marked/blob/master/src/Renderer.ts#L53

Fix: 

 https://docsify-preview.vercel.app/preview/#/zh-cn/

```
marked.esm.js:21 Uncaught (in promise) Error: Token with "link" type was not found.
Please report this to https://github.com/markedjs/marked.
    at ne.parse (marked.esm.js:21:1)
    at Object.heading (markdown-to-txt.js:62:25)
    at ne.parse (marked.esm.js:21:1)
    at parse (marked.esm.js:21:1)
    at Object.parse (marked.esm.js:15:21)
    at Function.oe [as parse] (marked.esm.js:15:21)
    at de (markdown-to-txt.js:191:28)
    at search.js:154:36
    at Array.forEach (<anonymous>)
    at search.js:109:10
```


<!--
Describe what the change does and why it should be merged.
Provide **before/after** screenshots for any UI changes.
-->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

Bugfix 

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
