### PR TITLE
chore: retire outdate multiple languages

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -17,6 +17,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
   # test
   npm run test
+  # update snapshot
+  npm run test:update:snapshot
 
   # commit
   git add -A

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -4,6 +4,3 @@
 
   - [English](/)
   - [简体中文](/zh-cn/)
-  - [Deutsch](/de-de/)
-  - [Español](/es/)
-  - [Русский](/ru-ru/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,7 @@
     <script>
       // Set html "lang" attribute based on URL
       (function () {
-        const lang = location.hash.match(/#\/(de-de|es|ru-ru|zh-cn)\//);
+        const lang = location.hash.match(/#\/(zh-cn)\//);
 
         if (lang) {
           document.documentElement.setAttribute('lang', lang[1]);
@@ -102,12 +102,6 @@
           '.*?/changelog':
             'https://raw.githubusercontent.com/docsifyjs/docsify/master/CHANGELOG.md',
           '/.*/_navbar.md': '/_navbar.md',
-          '/es/(.*)':
-            'https://raw.githubusercontent.com/docsifyjs/docs-es/master/$1',
-          '/de-de/(.*)':
-            'https://raw.githubusercontent.com/docsifyjs/docs-de/master/$1',
-          '/ru-ru/(.*)':
-            'https://raw.githubusercontent.com/docsifyjs/docs-ru/master/$1',
           '/zh-cn/(.*)':
             'https://cdn.jsdelivr.net/gh/docsifyjs/docs-zh@master/$1',
         },
@@ -129,9 +123,6 @@
         },
         name: 'docsify',
         nameLink: {
-          '/es/': '#/es/',
-          '/de-de/': '#/de-de/',
-          '/ru-ru/': '#/ru-ru/',
           '/zh-cn/': '#/zh-cn/',
           '/': '#/',
         },
@@ -139,26 +130,17 @@
           // insertAfter: '.app-name',
           // insertBefore: '.sidebar-nav',
           noData: {
-            '/es/': '¡No hay resultados!',
-            '/de-de/': 'Keine Ergebnisse!',
-            '/ru-ru/': 'Никаких результатов!',
             '/zh-cn/': '没有结果!',
             '/': 'No results!',
           },
           paths: 'auto',
           placeholder: {
-            '/es/': 'Buscar',
-            '/de-de/': 'Suche',
-            '/ru-ru/': 'Поиск',
             '/zh-cn/': '搜索',
             '/': 'Search',
           },
-          pathNamespaces: ['/es', '/de-de', '/ru-ru', '/zh-cn'],
+          pathNamespaces: ['/zh-cn'],
         },
         skipLink: {
-          '/es/': 'Saltar al contenido principal',
-          '/de-de/': 'Ga naar de hoofdinhoud',
-          '/ru-ru/': 'Перейти к основному содержанию',
           '/zh-cn/': '跳到主要内容',
         },
         vueComponents: {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "test:integration": "npm run test:jest -- --selectProjects integration",
     "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "test:unit": "npm run test:jest -- --selectProjects unit",
+    "test:update:snapshot": "npm run test:jest -- --updateSnapshot",
     "test": "run-s test:jest test:e2e",
     "watch:css": "run-p 'build:css -- --watch' 'build:css:min -- --watch'",
     "watch:js": "npm run build:js -- --watch"

--- a/test/integration/__snapshots__/docs.test.js.snap
+++ b/test/integration/__snapshots__/docs.test.js.snap
@@ -5,7 +5,7 @@ exports[`Docs Site coverpage renders and is unchanged 1`] = `
       <div class="mask"></div>
       <div class="cover-main"><!-- markdownlint-disable first-line-h1 -->
 
-<p><img src="http://127.0.0.1:4000/_media/icon.svg" data-origin="_media/icon.svg" alt="logo"></p><h1 id="docsify-4130" tabindex="-1"><a href="#/?id=docsify-4130" data-id="docsify-4130" class="anchor"><span>docsify <small>4.13.0</small></span></a></h1><blockquote>
+<p><img src="http://127.0.0.1:4000/_media/icon.svg" data-origin="_media/icon.svg" alt="logo"></p><h1 id="docsify-4131" tabindex="-1"><a href="#/?id=docsify-4131" data-id="docsify-4131" class="anchor"><span>docsify <small>4.13.1</small></span></a></h1><blockquote>
 <p>A magical documentation site generator</p></blockquote>
 <ul><li>Simple and lightweight</li><li>No statically built HTML files</li><li>Multiple themes</li></ul><p><a href="#/?id=docsify" class="button primary">Get Started</a>
 <a href="https://github.com/docsifyjs/docsify/" target="_blank" rel="noopener" class="button secondary">GitHub</a></p><!-- ![color](#f0f0f0) -->

--- a/test/integration/__snapshots__/docs.test.js.snap
+++ b/test/integration/__snapshots__/docs.test.js.snap
@@ -17,7 +17,7 @@ exports[`Docs Site coverpage renders and is unchanged 1`] = `
 exports[`Docs Site navbar renders and is unchanged 1`] = `
 "<nav class="app-nav" aria-label="secondary"><!-- markdownlint-disable first-line-h1 -->
 
-<ul><li><p>Translations</p><ul><li><a href="#/">English</a></li><li><a href="#/zh-cn/">简体中文</a></li><li><a href="#/de-de/">Deutsch</a></li><li><a href="#/es/">Español</a></li><li><a href="#/ru-ru/">Русский</a></li></ul></li></ul></nav>"
+<ul><li><p>Translations</p><ul><li><a href="#/">English</a></li><li><a href="#/zh-cn/">简体中文</a></li></ul></li></ul></nav>"
 `;
 
 exports[`Docs Site sidebar renders and is unchanged 1`] = `


### PR DESCRIPTION
We are about to release version V5.0.0-RC1, and since the documentation for these languages is not up to date and I am not sure if the previous maintainer is willing to continue to maintain it, I will ping here and if there is time to continue to maintain it, then it can be added back.

> btw, while we can use Ai for translations, we lack native language speakers for confirmation, and if there is no one to maintain it, then I'd still recommend removing it.
> We also welcome new contributors! ❤️

- [es](https://github.com/docsifyjs/docs-es) @SidVal
- [ru](https://github.com/docsifyjs/docs-ru) @lex111
- [de](https://github.com/docsifyjs/docs-de) @SidVal