### PR TITLE
chore: add depth configuration for search

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -139,6 +139,7 @@
             '/': 'Search',
           },
           pathNamespaces: ['/zh-cn'],
+          depth: 6,
         },
         skipLink: {
           '/zh-cn/': '跳到主要内容',


### PR DESCRIPTION
There is h6 content in the document, but the search configuration defaults to h2, so the relevant content is not searched.
