### PR TITLE
fix: exclude app-name-link from sidebar text overflow styling

### DIFF
--- a/src/themes/shared/_classes.css
+++ b/src/themes/shared/_classes.css
@@ -131,7 +131,7 @@ body.sidebar-chevron-right {
 /* ========================================================================== */
 body.sidebar-link-clamp {
   .sidebar {
-    a {
+    a:not(.app-name-link) {
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;


### PR DESCRIPTION
## Summary


## Related issue, if any:

Close #2563

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

Bugfix

<!--
  Copy/paste any of the relevant following options:

  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other

  If you choose Other, describe it.
-->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No
<!-- (pick one) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
