### PR TITLE
chore: remove themes directory from package.json files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "./*": "./*"
   },
   "files": [
-    "dist",
-    "themes"
+    "dist"
   ],
   "lint-staged": {
     "*.js": "eslint --fix"


### PR DESCRIPTION
We no longer need the themes directory.