### PR TITLE
fix: handle hash navigation to prevent duplicate callbacks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -917,7 +917,7 @@ If you have a link to the homepage in the sidebar and want it to be shown as act
 
 For more details, see [#1131](https://github.com/docsifyjs/docsify/issues/1131).
 
-## themeColor ⚠️
+## themeColor ⚠️ :id=themecolor
 
 !> Deprecated as of v5. Use the `--theme-color` [theme property](themes#theme-properties) to [customize](themes#customization) your theme color.
 
@@ -931,7 +931,7 @@ window.$docsify = {
 };
 ```
 
-## topMargin ⚠️
+## topMargin ⚠️ :id=topmargin
 
 !> Deprecated as of v5. Use the `--scroll-padding-top` [theme property](themes#theme-properties) to specify a scroll margin when using a sticky navbar.
 

--- a/src/core/router/history/hash.js
+++ b/src/core/router/history/hash.js
@@ -47,6 +47,15 @@ export class HashHistory extends History {
 
       if (el && el.tagName === 'A' && !isExternal(el.href)) {
         navigating = true;
+
+        // Do not compare hash containing these classes.
+        if (['app-name-link', 'page-link'].includes(el.className)) {
+          return;
+        }
+
+        if (el.hash === location.hash) {
+          cb({ event: e, source: 'navigate' });
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

This PR improves hash navigation handling by correctly setting the navigating flag even when the clicked link points to the current hash.

## Related issue, if any:

Close #522

## What kind of change does this PR introduce?

Bugfix

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
