### PR TITLE
fix: escape HTML in search keywords and trim sidebar id

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -1,5 +1,6 @@
 import { isMobile, mobileBreakpoint } from '../util/env.js';
 import * as dom from '../util/dom.js';
+import { stripUrlExceptId } from '../router/util.js';
 
 /** @typedef {import('../Docsify.js').Constructor} Constructor */
 
@@ -473,6 +474,8 @@ export function Events(Base) {
       if (!sidebar) {
         return;
       }
+
+      href = stripUrlExceptId(href);
 
       const oldActive = dom.find(sidebar, 'li.active');
       const newActive = dom

--- a/src/core/render/compiler/heading.js
+++ b/src/core/render/compiler/heading.js
@@ -4,6 +4,7 @@ import {
   getAndRemoveDocsifyIgnoreConfig,
 } from '../utils.js';
 import { slugify } from '../slugify.js';
+import { stripUrlExceptId } from '../../router/util.js';
 
 export const headingCompiler = ({ renderer, router, compiler }) =>
   (renderer.heading = function ({ tokens, depth }) {
@@ -20,7 +21,7 @@ export const headingCompiler = ({ renderer, router, compiler }) =>
     nextToc.ignoreSubHeading = ignoreSubHeading;
     const slug = slugify(config.id || str);
     const url = router.toURL(router.getCurrentPath(), { id: slug });
-    nextToc.slug = url;
+    nextToc.slug = stripUrlExceptId(url);
     compiler.toc.push(nextToc);
 
     // Note: tabindex="-1" allows programmatically focusing on heading

--- a/src/core/router/util.js
+++ b/src/core/router/util.js
@@ -40,6 +40,22 @@ export function stringifyQuery(obj, ignores = []) {
   return qs.length ? `?${qs.join('&')}` : '';
 }
 
+export function stripUrlExceptId(str) {
+  const [path, queryString] = str.split('?');
+  if (!queryString) {
+    return str;
+  }
+
+  const params = new URLSearchParams(queryString);
+  const id = params.get('id');
+
+  if (id !== null) {
+    return `${path}?id=${id}`;
+  }
+
+  return path;
+}
+
 export const isAbsolutePath = cached(path => {
   return /(:|(\/{2}))/g.test(path);
 });

--- a/src/plugins/search/component.js
+++ b/src/plugins/search/component.js
@@ -1,4 +1,4 @@
-import { search } from './search.js';
+import { escapeHtml, search } from './search.js';
 import cssText from './style.css';
 
 let NO_DATA_TEXT = '';
@@ -75,11 +75,11 @@ function bindEvents() {
   let timeId;
 
   /**
-    Prevent to Fold sidebar.
-
-    When searching on the mobile end,
-    the sidebar is collapsed when you click the INPUT box,
-    making it impossible to search.
+   * Prevent to Fold sidebar.
+   *
+   * When searching on the mobile end,
+   * the sidebar is collapsed when you click the INPUT box,
+   * making it impossible to search.
    */
   Docsify.dom.on(
     $search,
@@ -129,10 +129,10 @@ export function init(opts, vm) {
     return;
   }
 
-  const keywords = vm.router.parse().query.s;
+  const keywords = vm.router.parse().query.s || '';
 
   Docsify.dom.style(cssText);
-  tpl(vm, keywords);
+  tpl(vm, escapeHtml(keywords));
   bindEvents();
   keywords && setTimeout(_ => doSearch(keywords), 500);
 }

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -5,7 +5,7 @@ import {
 import { markdownToTxt } from './markdown-to-txt.js';
 import Dexie from 'dexie';
 
-let INDEXES = {};
+let INDEXES = [];
 
 const db = new Dexie('docsify');
 db.version(1).stores({
@@ -48,7 +48,7 @@ function resolveIndexKey(namespace) {
     : LOCAL_STORAGE.INDEX_KEY;
 }
 
-function escapeHtml(string) {
+export function escapeHtml(string) {
   const entityMap = {
     '&': '&amp;',
     '<': '&lt;',
@@ -102,7 +102,7 @@ function getListData(token) {
 export function genIndex(path, content = '', router, depth, indexKey) {
   const tokens = window.marked.lexer(content);
   const slugify = window.Docsify.slugify;
-  const index = {};
+  const index = [];
   let slug;
   let title = '';
 
@@ -299,7 +299,7 @@ export async function init(config, vm) {
   INDEXES = await getData(indexKey);
 
   if (isExpired) {
-    INDEXES = {};
+    INDEXES = [];
   } else if (!isAuto) {
     return;
   }


### PR DESCRIPTION
## Summary

<!-- Describe what the change does and why it should be merged. Provide **before/after** screenshots for any UI changes. -->

- Searching with ?s= may trigger an XSS injection， escape the search str.
- Introduce `function stripUrlExceptId` to ensure sidebar links only contains `id` as anchor.
  As-is

> v4
<img width="879" height="287" alt="image-v4" src="https://github.com/user-attachments/assets/4dc5e324-c2dc-4609-90ca-7723da4d2a00" />

---
> v5 rc1
<img width="884" height="302" alt="image-v5rc1" src="https://github.com/user-attachments/assets/ac4516e4-67de-44ad-9ce1-96d385ceced7" />



## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
