### PR TITLE
style: CSS updates for coverpage, iframe dark mode transparency and codeblock contast

### DIFF
--- a/src/themes/addons/core-dark.css
+++ b/src/themes/addons/core-dark.css
@@ -34,3 +34,11 @@
     border-color: rgba(255, 255, 255, 0.5);
   }
 }
+
+/* Force light mode for iframes in dark theme */
+iframe,
+iframe *,
+iframe[src],
+iframe[src] * {
+  color-scheme: light;
+}

--- a/src/themes/shared/_coverpage.css
+++ b/src/themes/shared/_coverpage.css
@@ -48,6 +48,7 @@
       &:hover {
         text-decoration-color: transparent;
       }
+      color: var(--cover-title-color);
     }
 
     small {

--- a/src/themes/shared/_vars.css
+++ b/src/themes/shared/_vars.css
@@ -95,7 +95,7 @@
   --callout-charm-translate       : -50% -50%;
   --callout-color                 : ;
   --callout-padding               : 1em 1em 1em var(--callout-charm-size);
-  --code-bg                       : var(--color-mono-1);
+  --code-bg                       : var(--color-mono-2);
   --code-color                    : ;
   --codeblock-bg                  : var(--code-bg);
   --codeblock-color               : var(--code-color);


### PR DESCRIPTION
## Summary

<!-- Describe what the change does and why it should be merged. Provide **before/after** screenshots for any UI changes. -->

CSS updates for the following:
- Fix for Coverpage title link colors 
- Fix for Transparent iframe support in dark mode
- Fix for inline codeblock contrast within shaded table rows

Also available for review and testing in codesandbox:
https://codesandbox.io/p/sandbox/docsify-v5-css-issues-6r26v7

View `index.html` to uncomment related CSS fix to see proposed changes, etc.

And here is the same test Docsify site using the updated theme files in this PR:
https://paulhibbitts.github.io/docsify-v5-css-issues/#/

(not sure why clicking on Quick start on Coverpage only scrolls down halfway, I think this is a pretty recent issue and also seems to be on https://preview.docsifyjs.org/#/ now but not in RC-1 https://paulhibbitts.github.io/docsify-v5-rc-1-coverpage/)

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Tested in the following browsers:

- [X] Chrome
- [X] Firefox
- [X] Safari
- [X] Edge
