### PR TITLE
fix: normalize slugs to NFC and remove emoji variation selector

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -288,7 +288,7 @@ Docsify provides [theme properties](#theme-properties) for simplified customizat
    }
    ```
 
-   ?> **Theme authors**: Consider providing instructions for loading your recommended web fonts manually instead of including them in your theme using `@import`. This allows users who prefer a different font to avoid loading your recommended web font(s) unnecessarily.
+   > [!TIP] **Theme authors**: Consider providing instructions for loading your recommended web fonts manually instead of including them in your theme using `@import`. This allows users who prefer a different font to avoid loading your recommended web font(s) unnecessarily.
 
 4. Advanced styling may require custom CSS declarations. This is expected, however custom CSS declarations may break when new versions of Docsify are released. When possible, leverage [theme properties](#theme-properties) instead of custom declarations or lock your [CDN](cdn) URLs to a [specific version](cdn#specific-version) to avoid potential issues when using custom CSS declarations.
 

--- a/src/core/render/slugify.js
+++ b/src/core/render/slugify.js
@@ -13,6 +13,7 @@ export function slugify(str) {
   let slug = str
     .trim()
     .normalize('NFKD')
+    .replace(/\uFE0F/g, '')
     .replace(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu, '')
     .replace(/[A-Z]+/g, lower)
     .replace(/<[^>]+>/g, '')

--- a/src/core/render/slugify.js
+++ b/src/core/render/slugify.js
@@ -12,7 +12,7 @@ export function slugify(str) {
 
   let slug = str
     .trim()
-    .normalize('NFKD')
+    .normalize('NFC')
     .replace(/\uFE0F/g, '')
     .replace(/[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu, '')
     .replace(/[A-Z]+/g, lower)

--- a/test/unit/render-util.test.js
+++ b/test/unit/render-util.test.js
@@ -179,7 +179,7 @@ describe('core/render/slugify', () => {
     expect(nestedHtmlStrippedSlug).toBe('another-broken-example');
 
     const emojiRemovedSlug = slugify('emoji test ⚠️🔥✅');
-    expect(emojiRemovedSlug).toBe('emoji-test-️');
+    expect(emojiRemovedSlug).toBe('emoji-test-');
 
     const multiSpaceSlug = slugify('Title    with   multiple spaces');
     expect(multiSpaceSlug).toBe('title----with---multiple-spaces');


### PR DESCRIPTION
## Summary

### Background

While generating slugs, we noticed two issues affecting consistency:

1. **Invisible FE0F (Variation Selector-16)**

   * Certain symbols can appear either as text or emoji, depending on whether they are followed by `U+FE0F`.

     * Text style: `✏` (U+270F)
     * Emoji style: `✏️` (U+270F U+FE0F)
   * If `FE0F` is not explicitly removed, the slug may contain invisible characters, leading to inconsistent URLs.

2. **NFKD decomposition side effects**

   * Using `normalize("NFKD")` decomposes precomposed characters like `é` (`U+00E9`) into `e + U+0301`.
   * This results in visually identical strings with different underlying byte sequences, which can cause issues in comparisons and storage.

### Changes

* **Remove `U+FE0F` explicitly**

  * Ensures emoji and text variants of the same symbol produce identical slugs.
  * Example:

    * `"✏ note"` → `"note"`
    * `"✏️ note"` → `"note"`

* **Switch normalization from NFKD → NFC**

  * Guarantees precomposed characters (like `é`) remain stable instead of being split into combining sequences.
  * Keeps accented characters intact, avoiding invisible combining marks in slugs.

### Examples

| Input                 | Old (NFKD, FE0F not removed) | New (NFC, FE0F removed) |
| --------------------- | ---------------------------- | ----------------------- |
| `café`                | `café` (`e + ◌́`)           | `café` (`U+00E9`)       |
| `✏ note`              | `note`                       | `note`                  |
| `✏️ note` (with FE0F) | `note` (contained FE0F)      | `note`                  |


## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
