### PR TITLE
fix: add test for file embed and code fragments

### DIFF
--- a/test/integration/example.test.js
+++ b/test/integration/example.test.js
@@ -134,4 +134,60 @@ describe('Creating a Docsify site (integration tests in Jest)', function () {
     ).toBeTruthy();
     expect(await waitForText('#main', 'This is a custom route')).toBeTruthy();
   });
+
+  test('embed file code fragment renders', async () => {
+    await docsifyInit({
+      markdown: {
+        homepage: `
+          # Embed Test
+
+          [filename](_media/example1.js ':include :type=code :fragment=demo')
+          
+          [filename](_media/example2.js ':include :type=code :fragment=demo')
+        `,
+      },
+      routes: {
+        // Serve the example.js file so the embed fetch can retrieve it
+        '_media/example1.js': `
+            let myURL = 'https://api.example.com/data';
+            /// [demo]
+            const result = fetch(myURL)
+              .then(response => {
+                return response.json();
+              })
+              .then(myJson => {
+                console.log(JSON.stringify(myJson));
+              });
+            /// [demo]
+
+            result.then(console.log).catch(console.error);
+        `,
+        '_media/example2.js': `
+            let myURL = 'https://api.example.com/data';
+            ### [demo]
+            const result = fetch(myURL)
+              .then(response => {
+                return response.json();
+              })
+              .then(myJson => {
+                console.log(JSON.stringify(myJson));
+              });
+            ### [demo]
+
+            result.then(console.log).catch(console.error);
+        `,
+      },
+    });
+
+    // Wait for the embedded fragment to be fetched and rendered into #main
+    expect(
+      await waitForText('#main', 'console.log(JSON.stringify(myJson));'),
+    ).toBeTruthy();
+    // Ensure the URL outside the fragment is NOT included in the embedded code
+    const mainText = document.querySelector('#main').textContent;
+    expect(mainText).not.toContain('https://api.example.com/data');
+    expect(mainText).not.toContain(
+      'result.then(console.log).catch(console.error);',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

<!-- Describe what the change does and why it should be merged. Provide **before/after** screenshots for any UI changes. -->
Had an idea of adding a full line code fragment keyword (simliar to `/// [demo]`). This would be useful in a HTML context, where there will be a trailing `-->` after a `/// [demo]` if it's wrapped in a comment. **Thought I should add some tests for the current file embed code fragment setup first at least.**

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [X] No

## Tested in the following browsers:

- [X] Chrome
- [X] Firefox
- [X] Safari
- [X] Edge
