### PR TITLE
fix broken link to issues in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We welcome any type of contribution, not only code. You can help with
 - **QA**: file bug reports, the more details you can give the better (e.g. screenshots with the console open)
 - **Marketing**: writing blog posts, howto's, printing stickers, ...
 - **Community**: presenting the project at meetups, organizing a dedicated meetup for the local community, ...
-- **Code**: take a look at the [open issues](https://github.com/docsifyjs/docsify/issues).. Even if you can't write code, commenting on them, showing that you care about a given issue matters. It helps us triage them.
+- **Code**: take a look at the [open issues](https://github.com/docsifyjs/docsify/issues). Even if you can't write code, commenting on them, showing that you care about a given issue matters. It helps us triage them.
 - **Money**: we welcome financial contributions in full transparency on our [open collective](https://opencollective.com/docsify).
 
 ## Your First Contribution


### PR DESCRIPTION
Changed relative link "issues" to absolute URL "https://github.com/docsifyjs/docsify/issues" to prevent 404.

## Summary

The `CONTRIBUTING.md` file contained a relative link `[open issues](issues)`, which leads to a 404 error because there is no `issues/` directory in the repo. This PR updates the link to the correct absolute URL.

**Before**:  
`[open issues](issues)` → leads to 404

**After**:  
`[open issues](https://github.com/docsifyjs/docsify/issues)` → opens the correct GitHub Issues page

## Related issue, if any:

N/A (self-identified documentation bug)

## What kind of change does this PR introduce?

- [x] Documentation content changes

## For any code change,

- [x] Related documentation has been updated, if needed

## Does this PR introduce a breaking change?

- [x] No

## Tested in the following browsers:

(Not applicable — this is a documentation-only change)