### PR TITLE
delete deprecation warning that was not meant to be added in #2392

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -119,13 +119,6 @@ const defaultDocsifyConfig = () => ({
  * @returns {DocsifyConfig}
  */
 export default function (vm, config = {}) {
-  if (window.$docsify) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'DEPRECATION: The global $docsify config variable is deprecated. See the latest getting started docs. https://docsify.js.org/#/quickstart',
-    );
-  }
-
   config = Object.assign(
     defaultDocsifyConfig(),
 


### PR DESCRIPTION
## Summary

Remove warning that was unintentionally included in

- #2392

## Related issue, if any:

- closes https://github.com/docsifyjs/docsify/issues/2645

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): delete console warning

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
