### PR TITLE
Docs add https + specific rc to index.html CDN links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,27 +21,28 @@
     <!-- Core Theme -->
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify@5/dist/themes/core.min.css"
+      s
+      href="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/themes/core.min.css"
     />
 
     <!-- Theme Add-on(s) -->
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify@5/dist/themes/addons/core-dark.min.css"
+      href="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/themes/addons/core-dark.min.css"
       media="(prefers-color-scheme: dark)"
       data-group="addon"
       data-sheet="core-dark-auto"
     />
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify@5/dist/themes/addons/core-dark.min.css"
+      href="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/themes/addons/core-dark.min.css"
       data-group="addon"
       data-sheet="core-dark"
       disabled
     />
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify@5/dist/themes/addons/vue.min.css"
+      href="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/themes/addons/vue.min.css"
       data-group="addon"
       data-sheet="vue"
       disabled
@@ -98,7 +99,7 @@
 
   <body class="loading sidebar-chevron-right sidebar-group-box">
     <div id="app"></div>
-    <script src="//cdn.jsdelivr.net/npm/docsify-plugin-carbon@1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify-plugin-carbon@1"></script>
     <script>
       // Docsify configuration
       window.$docsify = {
@@ -236,22 +237,22 @@
         ],
       };
     </script>
-    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/docsify.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/search.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/front-matter.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/gtag.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/matomo.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-markdown.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-nginx.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-php.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/docsify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/plugins/search.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/plugins/front-matter.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/plugins/gtag.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@5.0.0-rc.3/dist/plugins/matomo.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-markdown.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-nginx.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-php.min.js"></script>
 
     <!-- Vue: Development -->
     <!-- <script src="//cdn.jsdelivr.net/npm/vue@3/dist/vue.global.js"></script> -->
     <!-- <script src="//cdn.jsdelivr.net/npm/vue@3/dist/vue.runtime.global.js"></script> -->
 
     <!-- Vue: Production -->
-    <script src="//cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
     <!-- <script src="//cdn.jsdelivr.net/npm/vue@3/dist/vue.runtime.global.prod.js"></script> -->
   </body>
 </html>


### PR DESCRIPTION
## Summary

Does `docsify serve` work locally for you guys? I get a bunch of CDN fetching errors.

`Too many redirects` form the `src="//cdn.jsdelivr.net/...`.

Adding the `https://...` I still get `Failed to load resource: the server responded with a status of 404 ()`.

Adding the specific RC seems to fix that.

Am I missing something? Maybe just issues on my setup (tried Safari and Chrome)? 

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [ ] No

## Tested in the following browsers:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
