### PR TITLE
fix: gracefully handle page loading failures during search indexing

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -325,18 +325,37 @@ export async function init(config, vm) {
       return count++;
     }
 
+    const saveIfCompleted = () => {
+      if (len === ++count) {
+        saveData(config.maxAge, expireKey).catch(err => {
+          // eslint-disable-next-line no-console
+          console.warn('Search plugin: failed to save index data', err);
+        });
+      }
+    };
+
     Docsify.get(vm.router.getFile(path), false, vm.config.requestHeaders).then(
-      async result => {
-        INDEXES[path] = genIndex(
-          path,
-          result,
-          vm.router,
-          config.depth,
-          indexKey,
-        );
-        if (len === ++count) {
-          await saveData(config.maxAge, expireKey);
+      result => {
+        try {
+          INDEXES[path] = genIndex(
+            path,
+            result,
+            vm.router,
+            config.depth,
+            indexKey,
+          );
+        } finally {
+          saveIfCompleted();
         }
+      },
+      err => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Search plugin: failed to load a file for indexing',
+          path,
+          err,
+        );
+        saveIfCompleted();
       },
     );
   });

--- a/test/e2e/search.test.js
+++ b/test/e2e/search.test.js
@@ -333,4 +333,36 @@ console.log('Hello World');
       '...SearchHere to check it!...',
     );
   });
+
+  test('search should work if some page failed to load', async ({ page }) => {
+    const docsifyInitConfig = {
+      markdown: {
+        homepage: `
+          # Hello World
+
+          This is the homepage.
+        `,
+        sidebar: `
+          - [Test Page](test)
+          - [Broken Page](broken)
+        `,
+      },
+      routes: {
+        '/test.md': `
+          # Test Page
+
+          This is a custom route.
+        `,
+      },
+      scriptURLs: ['/dist/plugins/search.js'],
+    };
+
+    const searchFieldElm = page.locator('input[type=search]');
+    const resultsHeadingElm = page.locator('.results-panel .title');
+
+    await docsifyInit(docsifyInitConfig);
+
+    await searchFieldElm.fill('hello');
+    await expect(resultsHeadingElm).toHaveText('Hello World');
+  });
 });


### PR DESCRIPTION
## Summary

Gracefully handle page loading failures during the search indexing processing.

Before this fix, the loaded page counter was incremented only in the successful branch of `Docsify.get`, so if any request failed then the counter never reached the expected value and `saveData` was never called.

## Related issue, if any:

Fixes #2674 

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
