### PR TITLE
fix: preserve keyboard focus in sidebar after navigation on desktop

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -395,7 +395,9 @@ export function Events(Base) {
       }
 
       // Clicked anchor link or page load with anchor ID
-      if (hasId || isNavigate) {
+      // On desktop, preserve sidebar focus when navigating via sidebar links
+      // so keyboard users don't lose their place (see #2600)
+      if (hasId || (isNavigate && isMobile())) {
         this.#focusContent();
       }
     }


### PR DESCRIPTION
## Summary

Fixes #2600 — Keyboard focus is lost after activating sidebar links on desktop.

**Root cause:** `onNavigate()` unconditionally called `#focusContent()` whenever a user clicked a sidebar link, moving focus from the sidebar to the main content area. This caused keyboard-dependent users to lose their position in the navigation.

**Fix:** Only call `#focusContent()` after a user-initiated navigation when on mobile (where the sidebar closes). On desktop, the sidebar stays open and focus remains on the clicked link, so keyboard users can continue navigating without losing their place.

Focus is still correctly moved to content when:
- Navigating to a specific heading anchor (`?id=...`)
- On mobile, where the sidebar closes after navigation

## Changes

- `src/core/event/index.js`: Changed the condition in `onNavigate()` from `hasId || isNavigate` to `hasId || (isNavigate && isMobile())` to preserve sidebar focus on desktop.

## Testing

- All unit tests pass (35/35)
- All integration tests pass (60/60)
- Build succeeds
- `isMobile()` was already imported and used in the same method for sidebar close logic, so this change is consistent with the existing pattern.

## Test plan

- [ ] On desktop: click a sidebar link with keyboard (Tab + Enter) — focus should remain on the sidebar link
- [ ] On desktop: click a sidebar anchor link (e.g., heading) — focus should move to the heading in content
- [ ] On mobile: click a sidebar link — sidebar should close and focus should move to content
- [ ] Browser forward/back navigation should be unaffected

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*