### PR TITLE
fix(search): save index even when some pages fail to load

### DIFF
--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -338,7 +338,8 @@ export async function init(config, vm) {
           await saveData(config.maxAge, expireKey);
         }
       },
-      async _error => {
+      async error => {
+        console.warn(`[Docsify] Failed to fetch ${path} for search indexing`, error);
         if (len === ++count) {
           await saveData(config.maxAge, expireKey);
         }

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -339,7 +339,9 @@ export async function init(config, vm) {
         }
       },
       async (_event, response) => {
-        console.warn(`[Docsify] Failed to fetch ${path} for search indexing (${response?.status || 'network error'})`);
+        console.warn(
+          `[Docsify] Failed to fetch ${path} for search indexing (${response?.status || 'network error'})`,
+        );
         if (len === ++count) {
           await saveData(config.maxAge, expireKey);
         }

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -338,8 +338,8 @@ export async function init(config, vm) {
           await saveData(config.maxAge, expireKey);
         }
       },
-      async error => {
-        console.warn(`[Docsify] Failed to fetch ${path} for search indexing`, error);
+      async (_event, response) => {
+        console.warn(`[Docsify] Failed to fetch ${path} for search indexing (${response?.status || 'network error'})`);
         if (len === ++count) {
           await saveData(config.maxAge, expireKey);
         }

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -338,6 +338,11 @@ export async function init(config, vm) {
           await saveData(config.maxAge, expireKey);
         }
       },
+      async _error => {
+        if (len === ++count) {
+          await saveData(config.maxAge, expireKey);
+        }
+      },
     );
   });
 }


### PR DESCRIPTION
## Summary

- **Issue:** When the search plugin indexes pages in auto mode, if any sidebar link returns a 404 (or any fetch error), the entire search index is lost. No search results are available — even for pages that loaded successfully.
- **Root cause:** `Docsify.get().then()` in `search.js` has no rejection handler. When a fetch fails, `count` is never incremented for that path, so `count` never reaches `len`, and `saveData()` is never called.
- **Fix:** Add an error handler callback to `.then()` that logs a warning and increments `count`, ensuring `saveData()` is called once all paths have been attempted.

## Changes

`src/plugins/search/search.js`:
- Added a second callback (error handler) to the `.then()` call, matching the custom ajax signature `(_event, response)`
- Logs a `console.warn` with the failed path and HTTP status code (e.g. `[Docsify] Failed to fetch /broken-page for search indexing (404)`) for easier debugging
- Increments `count` so that `saveData()` is still called when all fetches complete, preserving the index for pages that loaded successfully

## Test plan

- [ ] Set up a docsify site with search enabled and `auto` indexing
- [ ] Add a broken link in the sidebar (pointing to a non-existent `.md` file)
- [ ] Verify that search still works for all other pages
- [ ] Verify a warning appears in the browser console for the failed fetch
- [ ] Verify that search works normally when all links are valid (no regression)

Fixes #2674

🤖 Generated with [Claude Code](https://claude.com/claude-code)