### PR TITLE
fix: strip HTML tags from config.name when setting page title

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -329,10 +329,11 @@ export function Events(Base) {
         .find(`.sidebar a[href='${currentPath}']`)
         ?.getAttribute('title');
 
-      const currentTitle = name
+      const plainName = name ? name.replace(/<[^>]+>/g, '').trim() : name;
+      const currentTitle = plainName
         ? currentSection
-          ? `${currentSection} - ${name}`
-          : name
+          ? `${currentSection} - ${plainName}`
+          : plainName
         : currentSection;
 
       // Update page title


### PR DESCRIPTION
## Summary

- **Issue:** The `name` config option supports HTML markup (e.g. `<img src="logo.png">My Site`) for rendering logos in the sidebar. However, this raw HTML is also used directly as part of `document.title`, causing the browser tab to display ugly markup like `<img src="logo.png">My Site - Page Title`.
- **Fix:** Strip HTML tags from `name` using a regex before constructing the page title string, so only plain text content appears in the browser tab.

## Changes

`src/core/event/index.js` — `onRender()` method:
- Added `plainName` variable that strips HTML tags from `config.name` via `name.replace(/<[^>]+>/g, '').trim()`
- Used `plainName` instead of `name` when constructing `currentTitle` for `document.title`

### Before
```
name = '<img src="logo.png">My Site'
→ document.title = "Page - <img src=\"logo.png\">My Site"
```

### After
```
name = '<img src="logo.png">My Site'
→ document.title = "Page - My Site"
```

## Test plan

- [ ] Set `name` to a value containing HTML (e.g. `<img src="logo.png"><strong>My Site</strong>`)
- [ ] Verify the browser tab title shows only plain text (e.g. `Page - My Site`)
- [ ] Verify the sidebar still renders the HTML correctly (logo + styled text)
- [ ] Verify pages with plain text `name` config still work normally

Fixes #2610

🤖 Generated with [Claude Code](https://claude.com/claude-code)