### PR TITLE
feat: add pageTitleFormatter config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,7 +277,7 @@ window.$docsify = {
 
 ## pageTitleFormatter
 
-- Type: `Function | null`
+- Type: `Function`
 - Default: `null`
 
 Optional function to customize how the site `name` is used when composing the document title. If provided, Docsify will call this function with the configured `name` (which may contain HTML) and use the returned string as the title portion for the site name — Docsify will not automatically strip HTML or otherwise modify the value. If not provided, Docsify falls back to the default behavior of stripping HTML tags from `name`.
@@ -474,7 +474,7 @@ window.$docsify = {
 
 ## name
 
-- Type: `Boolean | String`
+- Type: `Boolean|String`
 
 Website name as it appears in the sidebar.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,6 +275,24 @@ window.$docsify = {
 };
 ```
 
+## pageTitleFormatter
+
+- Type: `Function | null`
+- Default: `null`
+
+Optional function to customize how the site `name` is used when composing the document title. If provided, Docsify will call this function with the configured `name` (which may contain HTML) and use the returned string as the title portion for the site name — Docsify will not automatically strip HTML or otherwise modify the value. If not provided, Docsify falls back to the default behavior of stripping HTML tags from `name`.
+
+Basic example — strip HTML and trim (equivalent to Docsify's default behavior):
+
+```js
+window.$docsify = {
+  name: '<span>My Site</span>',
+  pageTitleFormatter(name) {
+    return name ? name.replace(/<[^>]+>/g, '').trim() : '';
+  },
+};
+```
+
 ## hideSidebar
 
 - Type : `Boolean`

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -27,6 +27,7 @@ const defaultDocsifyConfig = () => ({
   fallbackLanguages: /** @type {null | string[]} */ (null),
   fallbackDefaultLanguage: '',
   formatUpdated: /** @type {string | ((updatedAt: string) => string)} */ (''),
+  pageTitleFormatter: /** @type {null | ((name: string) => string)} */ (null),
   /** For the frontmatter plugin. */
   frontMatter: /** @type {Record<string, TODO> | null} */ (null),
   hideSidebar: false,

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -323,13 +323,21 @@ export function Events(Base) {
      * @void
      */
     onRender() {
-      const { name } = this.config;
+      const { name, pageTitleFormatter } = this.config;
       const currentPath = this.router.toURL(this.router.getCurrentPath());
       const currentSection = dom
         .find(`.sidebar a[href='${currentPath}']`)
         ?.getAttribute('title');
 
-      const plainName = name ? name.replace(/<[^>]+>/g, '').trim() : name;
+      // If a pageTitleFormatter is provided, let the user format the name
+      // (no automatic HTML stripping). Otherwise, default to stripping
+      // HTML tags from the configured name.
+      const plainName =
+        typeof pageTitleFormatter === 'function'
+          ? pageTitleFormatter(name)
+          : name
+          ? name.replace(/<[^>]+>/g, '').trim()
+          : name;
       const currentTitle = plainName
         ? currentSection
           ? `${currentSection} - ${plainName}`

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -333,7 +333,7 @@ export function Events(Base) {
       // (no automatic HTML stripping). Otherwise, default to stripping
       // HTML tags from the configured name.
       const plainName =
-        typeof pageTitleFormatter === 'function'
+        typeof pageTitleFormatter === 'function' && typeof name === 'string'
           ? pageTitleFormatter(name)
           : name
             ? name.replace(/<[^>]+>/g, '').trim()

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -336,8 +336,8 @@ export function Events(Base) {
         typeof pageTitleFormatter === 'function'
           ? pageTitleFormatter(name)
           : name
-          ? name.replace(/<[^>]+>/g, '').trim()
-          : name;
+            ? name.replace(/<[^>]+>/g, '').trim()
+            : name;
       const currentTitle = plainName
         ? currentSection
           ? `${currentSection} - ${plainName}`


### PR DESCRIPTION
## Summary

<!-- Describe what the change does and why it should be merged. Provide **before/after** screenshots for any UI changes. -->

If a pageTitleFormatter is provided, let the user format the name
(no automatic HTML stripping). Otherwise, default to stripping
HTML tags from the configured name.

## Related issue, if any:

Close #2610

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
