### PR TITLE
docs: remove Matomo plugin and update embedded website link

### DIFF
--- a/docs/embed-files.md
+++ b/docs/embed-files.md
@@ -94,10 +94,10 @@ If you embed the file as `iframe`, `audio` and `video`, then you may need to set
 ```
 
 ```markdown
-[cinwell website](https://google.com ':include :type=iframe width=100% height=400px')
+[cinwell website](https://cinwell.com ':include :type=iframe width=100% height=400px')
 ```
 
-[cinwell website](https://google.com ':include :type=iframe width=100% height=400px')
+[cinwell website](https://cinwell.com ':include :type=iframe width=100% height=400px')
 
 Did you see it? You only need to write directly. You can check [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) for these attributes.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,10 +123,6 @@
         // routerMode: 'history',
         subMaxLevel: 2,
         gtag: 'G-H77Y58DS3L',
-        matomo: {
-          host: '//matomo.thunderwave.de',
-          id: 6,
-        },
         name: 'docsify',
         nameLink: {
           '/zh-cn/': '#/zh-cn/',
@@ -240,7 +236,6 @@
     <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/search.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/front-matter.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/gtag.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/matomo.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-markdown.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-nginx.min.js"></script>


### PR DESCRIPTION
## Summary

<!-- Describe what the change does and why it should be merged. Provide **before/after** screenshots for any UI changes. -->

The Matomo instance was deployed by @timaschew. I tried contacting him, but didn't receive a reply, so I removed it for now.

Revert cinwell's changes.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
