### PR TITLE
fix(router): implement normalize() method for HTML5History

### DIFF
--- a/src/core/router/history/html5.js
+++ b/src/core/router/history/html5.js
@@ -1,6 +1,6 @@
 import { isExternal, noop } from '../../util/core.js';
 import { on } from '../../util/dom.js';
-import { parseQuery, getPath } from '../util.js';
+import { parseQuery, getPath, replaceSlug, cleanPath } from '../util.js';
 import { History } from './base.js';
 
 export class HTML5History extends History {
@@ -62,5 +62,28 @@ export class HTML5History extends History {
       query: parseQuery(query),
       response: {},
     };
+  }
+
+  /**
+   * Normalize the current path
+   * Handles slug replacement and ensures path is properly formatted
+   */
+  normalize() {
+    let path = this.getCurrentPath();
+
+    path = replaceSlug(path);
+
+    if (path.charAt(0) !== '/') {
+      path = '/' + path;
+    }
+
+    // Update the URL if needed (without reloading)
+    const currentPath = this.getCurrentPath();
+    if (currentPath !== path) {
+      const url = window.location.pathname.replace(currentPath, path) + 
+                  window.location.search + 
+                  window.location.hash;
+      window.history.replaceState(window.history.state, '', cleanPath(url));
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2700

The HTML5History class was missing the normalize() method that is called in Router.updateRender(). This caused a crash when using routerMode: 'history' with the error 'Subclass should implement'.

## Changes

- Added normalize() method to HTML5History class
- The method applies slug replacement via replaceSlug()
- Ensures paths start with '/'
- Updates the URL via replaceState() if the path changed (without page reload)

## Testing

The fix follows the same pattern as HashHistory.normalize() but adapted for HTML5 history mode (using replaceState instead of hash manipulation).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Changes are focused and minimal
- [x] Related issue is referenced