### PR TITLE
feat: Option to position sidebar on the right (close #1282)

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -49,6 +49,7 @@ const defaultDocsifyConfig = () => ({
     false
   ),
   onlyCover: false,
+  sidebarPosition: /** @type {'left' | 'right'} */ ('left'),
   plugins: /** @type {Plugin[]} */ ([]),
   relativePath: false,
   repo: /** @type {string} */ (''),

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -626,6 +626,11 @@ export function Render(Base) {
         }
       }
 
+      // Set sidebar position on body
+      if (config.sidebarPosition === 'right') {
+        dom.$.body.setAttribute('data-sidebar-position', 'right');
+      }
+
       this._updateRender();
       dom.body.classList.add('ready');
     }

--- a/src/themes/shared/_app.css
+++ b/src/themes/shared/_app.css
@@ -41,10 +41,16 @@ main {
   > .content {
     position: absolute;
     inset: 0;
-    transition: left var(--duration-medium) ease;
+    transition: left var(--duration-medium) ease, right var(--duration-medium) ease;
 
     body:has(.sidebar.show) & {
       left: var(--sidebar-width);
+    }
+
+    /* Right sidebar position */
+    body[data-sidebar-position='right']:has(.sidebar.show) & {
+      left: 0;
+      right: var(--sidebar-width);
     }
 
     /* hideSidebar: true */

--- a/src/themes/shared/_mq.css
+++ b/src/themes/shared/_mq.css
@@ -58,6 +58,19 @@
     main > .content {
       left: 0;
     }
+
+    /* Right sidebar on mobile */
+    body[data-sidebar-position='right']:has(.sidebar.show) {
+      .app-nav {
+        left: auto;
+        right: 0;
+      }
+
+      main > .content {
+        left: auto;
+        right: 0;
+      }
+    }
   }
 
   body:has(.app-nav-merged) {

--- a/src/themes/shared/_sidebar.css
+++ b/src/themes/shared/_sidebar.css
@@ -114,6 +114,15 @@
     translate var(--duration-medium) ease,
     visibility var(--duration-medium);
 
+  /* Right sidebar position */
+  [data-sidebar-position='right'] & {
+    left: auto;
+    right: 0;
+    translate: calc(0px + var(--sidebar-width));
+    border-right: none;
+    border-left: 1px solid var(--sidebar-border-color);
+  }
+
   /* Non-webkit browsers: style scrollbar for consistency */
   @supports (scrollbar-width: auto) {
     &::-webkit-scrollbar {
@@ -231,6 +240,23 @@
 
   body:where(:has(.sidebar.show)) & {
     translate: var(--sidebar-width);
+    transition:
+      background 0s,
+      translate var(--duration-medium) ease;
+  }
+
+  /* Right sidebar position */
+  body[data-sidebar-position='right'] & {
+    left: auto;
+    right: 0;
+
+    &.show {
+      translate: calc(0px - var(--sidebar-width));
+    }
+  }
+
+  body[data-sidebar-position='right']:has(.sidebar.show) & {
+    translate: calc(0px - var(--sidebar-width));
     transition:
       background 0s,
       translate var(--duration-medium) ease;


### PR DESCRIPTION
## Summary

This PR implements the feature requested in issue #1282 - the ability to position the sidebar on the right side of the content.

### Changes

1. **New Config Option**: Added `sidebarPosition` option to config that accepts `'left'` (default) or `'right'`

2. **CSS Implementation**: Updated sidebar styles to handle right-side positioning with proper borders, transitions, and mobile responsive behavior

3. **JavaScript Integration**: Set `data-sidebar-position` attribute on body element based on config

### Usage

```javascript
window.$docsify = {
  sidebarPosition: 'right'  // sidebar appears on the right
}
```

### Files Changed

- `src/core/config.js` - Added `sidebarPosition` config option
- `src/core/render/index.js` - Set body attribute based on config  
- `src/themes/shared/_sidebar.css` - Right-side positioning styles
- `src/themes/shared/_app.css` - Content offset for right sidebar
- `src/themes/shared/_mq.css` - Mobile responsive fixes for right sidebar

### Use Cases

- RTL (right-to-left) language support
- Personal preference for right-side navigation
- Flexibility in documentation layout

Closes #1282