### PR TITLE
feat(search): resultSource option shows where results come from

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -65,6 +65,11 @@ By default, the hyperlink on the current page is recognized and the content is s
       // You can provide a regexp to match prefixes. In this case,
       // the matching substring will be used to identify the index
       pathNamespaces: /^(\/(zh-cn|ru-ru))?(\/(v1|v2))?/,
+
+      // Show where each result comes from (default: 'none')
+      // 'page': the page title, e.g. "Guide"
+      // 'breadcrumb': the sidebar path, e.g. "Basics › Guide"
+      resultSource: 'none',
     },
   };
 </script>

--- a/src/plugins/search/component.js
+++ b/src/plugins/search/component.js
@@ -3,6 +3,118 @@ import cssText from './style.css';
 import { escapeHtml } from '../../core/render/utils.js';
 
 let NO_DATA_TEXT = '';
+let RESULT_SOURCE = 'none';
+
+// Strip emoji (pictographs, flags, variation selectors, ZWJ, keycaps) from
+// sidebar labels and page titles so source labels stay plain text.
+function stripEmoji(text) {
+  return (text || '')
+    .replace(
+      /(?:[\uD83C-\uD83E][\uDC00-\uDFFF])|[\u2600-\u27BF\u2B00-\u2BFF]|\uFE0E|\uFE0F|\u200D|\u20E3/g,
+      '',
+    )
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function findSidebarLink(url) {
+  const base = decodeURIComponent((url || '').split('?')[0]);
+
+  return Docsify.dom
+    .findAll('.sidebar-nav a')
+    .find(
+      a =>
+        decodeURIComponent((a.getAttribute('href') || '').split('?')[0]) ===
+        base,
+    );
+}
+
+// Label of a sidebar list item: its own text or link text, without the text
+// of the nested list of children.
+function groupLabel(li) {
+  for (const node of li.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+      return node.textContent.trim();
+    }
+
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node.tagName === 'UL') {
+        break;
+      }
+
+      const text = node.textContent.trim();
+
+      if (text) {
+        return text;
+      }
+    }
+  }
+
+  return '';
+}
+
+// Walk the sidebar tree from the link matching the result URL up to the
+// root, collecting section labels along the way.
+function getBreadcrumb(url) {
+  const link = findSidebarLink(url);
+
+  if (!link) {
+    return null;
+  }
+
+  const parts = [link.textContent.trim()];
+  let li = link.closest('li');
+
+  while (li) {
+    const parentLi = li.parentElement ? li.parentElement.closest('li') : null;
+
+    if (parentLi) {
+      const label = groupLabel(parentLi);
+
+      if (label) {
+        parts.unshift(label);
+      }
+    }
+
+    li = parentLi;
+  }
+
+  return parts;
+}
+
+function resultSourceHtml(post) {
+  if (RESULT_SOURCE === 'breadcrumb') {
+    const parts = getBreadcrumb(post.url);
+
+    if (parts && parts.length) {
+      const crumbs = parts
+        .map((part, i) => {
+          const label = escapeHtml(stripEmoji(part));
+          // The page itself (last segment) stands out from its sections.
+          return i === parts.length - 1 ? `<strong>${label}</strong>` : label;
+        })
+        .join(' › ');
+
+      return /* html */ `<p class="search-breadcrumb clamp-1">${crumbs}</p>`;
+    }
+
+    // The page is not in the sidebar: fall back to its page title.
+    return post.page
+      ? /* html */ `<p class="search-breadcrumb clamp-1"><strong>${stripEmoji(post.page)}</strong></p>`
+      : '';
+  }
+
+  if (RESULT_SOURCE === 'page') {
+    // Skip the label when the matched title is the page title itself.
+    const page = post.page && post.page !== post.title ? post.page : '';
+
+    return page
+      ? /* html */ `<p class="search-breadcrumb clamp-1"><strong>${stripEmoji(page)}</strong></p>`
+      : '';
+  }
+
+  return '';
+}
 
 function tpl(vm, defaultValue = '') {
   const { insertAfter, insertBefore } = vm.config?.search || {};
@@ -59,6 +171,7 @@ function doSearch(value) {
         <a href="${post.url}" title="${title}">
           <p class="title clamp-1">${post.title}</p>
           <p class="content clamp-2">${content}</p>
+          ${resultSourceHtml(post)}
         </a>
       </div>
     `;
@@ -141,6 +254,7 @@ export function init(opts, vm) {
 
   const keywords = vm.router.parse().query.s || '';
 
+  RESULT_SOURCE = opts.resultSource || RESULT_SOURCE;
   Docsify.dom.style(cssText);
   tpl(vm, escapeHtml(keywords));
   bindEvents();
@@ -148,6 +262,7 @@ export function init(opts, vm) {
 }
 
 export function update(opts, vm) {
+  RESULT_SOURCE = opts.resultSource || RESULT_SOURCE;
   updatePlaceholder(opts.placeholder, vm.route.path);
   updateNoData(opts.noData, vm.route.path);
 }

--- a/src/plugins/search/component.js
+++ b/src/plugins/search/component.js
@@ -17,15 +17,23 @@ function stripEmoji(text) {
     .trim();
 }
 
+// User-authored links may contain malformed percent-encoding, on which
+// decodeURIComponent() throws.
+function safeDecode(uri) {
+  try {
+    return decodeURIComponent(uri);
+  } catch {
+    return uri;
+  }
+}
+
 function findSidebarLink(url) {
-  const base = decodeURIComponent((url || '').split('?')[0]);
+  const base = safeDecode((url || '').split('?')[0]);
 
   return Docsify.dom
     .findAll('.sidebar-nav a')
     .find(
-      a =>
-        decodeURIComponent((a.getAttribute('href') || '').split('?')[0]) ===
-        base,
+      a => safeDecode((a.getAttribute('href') || '').split('?')[0]) === base,
     );
 }
 

--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -16,7 +16,7 @@ import { init as initSearch } from './search.js';
  *   keyBindings: string[];
  *   insertAfter?: string;
  *   insertBefore?: string;
- *   resultSource: 'none' | 'page' | 'breadcrumb';
+ *   resultSource?: 'none' | 'page' | 'breadcrumb';
  * }} */
 const CONFIG = {
   placeholder: 'Type to search',

--- a/src/plugins/search/index.js
+++ b/src/plugins/search/index.js
@@ -16,6 +16,7 @@ import { init as initSearch } from './search.js';
  *   keyBindings: string[];
  *   insertAfter?: string;
  *   insertBefore?: string;
+ *   resultSource: 'none' | 'page' | 'breadcrumb';
  * }} */
 const CONFIG = {
   placeholder: 'Type to search',
@@ -28,6 +29,7 @@ const CONFIG = {
   keyBindings: ['/', 'meta+k', 'ctrl+k'],
   insertAfter: undefined, // CSS selector
   insertBefore: undefined, // CSS selector
+  resultSource: 'none', // 'none' | 'page' | 'breadcrumb'
 };
 
 const install = function (hook, vm) {
@@ -45,6 +47,7 @@ const install = function (hook, vm) {
     CONFIG.namespace = opts.namespace || CONFIG.namespace;
     CONFIG.pathNamespaces = opts.pathNamespaces || CONFIG.pathNamespaces;
     CONFIG.keyBindings = opts.keyBindings || CONFIG.keyBindings;
+    CONFIG.resultSource = opts.resultSource || CONFIG.resultSource;
   }
 
   const isAuto = CONFIG.paths === 'auto';

--- a/src/plugins/search/search.js
+++ b/src/plugins/search/search.js
@@ -232,6 +232,7 @@ export function genIndex(path, content = '', router, depth, indexKey) {
   const index = {};
   let slug;
   let title = '';
+  let pageTitle = '';
 
   tokens.forEach((token, tokenIndex) => {
     if (token.type === 'heading' && token.depth <= depth) {
@@ -242,6 +243,10 @@ export function genIndex(path, content = '', router, depth, indexKey) {
       if (str) {
         title = getAndRemoveDocsifyIgnoreConfig(str).content;
         title = removeAtag(title.trim());
+      }
+
+      if (!pageTitle && title) {
+        pageTitle = title;
       }
 
       index[slug] = {
@@ -292,6 +297,13 @@ export function genIndex(path, content = '', router, depth, indexKey) {
     }
   });
   slugify.clear();
+
+  // Let every entry know which page it belongs to, so search results can
+  // show the page title next to matched section titles.
+  Object.values(index).forEach(item => {
+    item.pageTitle = pageTitle;
+  });
+
   return index;
 }
 
@@ -368,11 +380,15 @@ export function search(query) {
       });
 
       if (matchesScore > 0) {
+        const postPageTitle = post.pageTitle && post.pageTitle.trim();
         const matchingPost = {
           title: handlePostTitle,
           content: postContent ? resultStr : '',
           url: postUrl,
           score: matchesScore,
+          page: postPageTitle
+            ? escapeHtml(ignoreDiacriticalMarks(postPageTitle))
+            : '',
         };
 
         matchingResults.push(matchingPost);

--- a/src/plugins/search/style.css
+++ b/src/plugins/search/style.css
@@ -148,6 +148,13 @@
   font-size: var(--font-size-s);
 }
 
+.search .matching-post .search-breadcrumb {
+  margin: 0.35em 0 0 0;
+  color: var(--color-mono-7);
+  font-size: var(--font-size-s);
+  text-align: right;
+}
+
 .search .results-status {
   margin-bottom: 0;
   color: var(--color-mono-6);

--- a/test/e2e/search.test.js
+++ b/test/e2e/search.test.js
@@ -131,6 +131,12 @@ test.describe('Search Plugin Tests', () => {
       await searchFieldElm.fill('volcanoes');
       await expect(resultsHeadingElm).toHaveText('Deep Section');
       await expect(resultsPageElm).toHaveText('Guides › Test Page');
+
+      // A page absent from the sidebar falls back to its page title.
+      await page.click('.clear-button');
+      await searchFieldElm.fill('homepage');
+      await expect(resultsHeadingElm).toHaveText('Hello World');
+      await expect(resultsPageElm).toHaveText('Hello World');
     });
   });
 

--- a/test/e2e/search.test.js
+++ b/test/e2e/search.test.js
@@ -36,6 +36,104 @@ test.describe('Search Plugin Tests', () => {
     await expect(resultsHeadingElm).toHaveText('Test Page');
   });
 
+  test.describe('resultSource option', () => {
+    const markdown = {
+      homepage: `
+        # Hello World
+
+        This is the homepage.
+      `,
+      sidebar: `
+        - Guides 📚
+          - [Test Page 🚀](test)
+      `,
+    };
+    const routes = {
+      '/test.md': `
+        # Test Page 🧪
+
+        This is a custom route.
+
+        ## Deep Section
+
+        Content about volcanoes.
+      `,
+    };
+
+    test('shows nothing by default', async ({ page }) => {
+      const docsifyInitConfig = {
+        markdown,
+        routes,
+        scriptURLs: ['/dist/plugins/search.js'],
+      };
+
+      const searchFieldElm = page.locator('input[type=search]');
+      const resultsHeadingElm = page.locator('.results-panel .title');
+      const resultsPageElm = page.locator('.results-panel .search-breadcrumb');
+
+      await docsifyInit(docsifyInitConfig);
+
+      await searchFieldElm.fill('volcanoes');
+      await expect(resultsHeadingElm).toHaveText('Deep Section');
+      await expect(resultsPageElm).toHaveCount(0);
+    });
+
+    test('page mode shows page title for section matches', async ({ page }) => {
+      const docsifyInitConfig = {
+        config: {
+          search: {
+            resultSource: 'page',
+          },
+        },
+        markdown,
+        routes,
+        scriptURLs: ['/dist/plugins/search.js'],
+      };
+
+      const searchFieldElm = page.locator('input[type=search]');
+      const resultsHeadingElm = page.locator('.results-panel .title');
+      const resultsPageElm = page.locator('.results-panel .search-breadcrumb');
+
+      await docsifyInit(docsifyInitConfig);
+
+      // A match inside a section shows which page it comes from,
+      // with emoji stripped from the page title.
+      await searchFieldElm.fill('volcanoes');
+      await expect(resultsHeadingElm).toHaveText('Deep Section');
+      await expect(resultsPageElm).toHaveText('Test Page');
+
+      // A match on the page title itself does not repeat the page title.
+      await page.click('.clear-button');
+      await searchFieldElm.fill('custom route');
+      await expect(resultsHeadingElm).toHaveText('Test Page 🧪');
+      await expect(resultsPageElm).toHaveCount(0);
+    });
+
+    test('breadcrumb mode shows sidebar path to the page', async ({ page }) => {
+      const docsifyInitConfig = {
+        config: {
+          search: {
+            resultSource: 'breadcrumb',
+          },
+        },
+        markdown,
+        routes,
+        scriptURLs: ['/dist/plugins/search.js'],
+      };
+
+      const searchFieldElm = page.locator('input[type=search]');
+      const resultsHeadingElm = page.locator('.results-panel .title');
+      const resultsPageElm = page.locator('.results-panel .search-breadcrumb');
+
+      await docsifyInit(docsifyInitConfig);
+
+      // Emoji from sidebar labels are stripped from the breadcrumb.
+      await searchFieldElm.fill('volcanoes');
+      await expect(resultsHeadingElm).toHaveText('Deep Section');
+      await expect(resultsPageElm).toHaveText('Guides › Test Page');
+    });
+  });
+
   test('search ignore title', async ({ page }) => {
     const docsifyInitConfig = {
       markdown: {


### PR DESCRIPTION
## Summary

Search results for matches inside a section only show the section heading, with no hint of which page the result belongs to. On docs sites where many pages share similar section names ("Usage", "Options", "Examples"), it is hard to tell the results apart.

This PR adds a `resultSource` option to the search plugin that renders, below each result excerpt, where the result comes from:

- `'none'` (default): current behavior, nothing extra renders
- `'page'`: the title of the page (its first heading), omitted when the matched title is the page title itself
- `'breadcrumb'`: the sidebar path to the page, e.g. "Getting started › **Cover page**", falling back to the page title for pages not present in the sidebar

```js
window.$docsify = {
  search: {
    resultSource: 'breadcrumb', // 'none' | 'page' | 'breadcrumb'
  },
};
```

Implementation notes:

- `genIndex()` stamps every index entry with the title of its page (`pageTitle`), and `search()` exposes it on results as `page`
- the breadcrumb is computed at render time by walking the rendered `.sidebar-nav` tree from the link matching the result URL up to the root
- emoji in sidebar labels and page titles are stripped so the source line stays plain text; the label is right-aligned, slightly muted (`--color-mono-7`) and the page segment renders in `<strong>`
- default `'none'` keeps the current behavior, so nothing changes for existing sites

Preview (`resultSource: 'breadcrumb'` on the docsify docs):

![Search results with breadcrumb source labels](https://raw.githubusercontent.com/piecioshka/docsify/assets-search-breadcrumb/search-breadcrumb.png)

## Related issue, if any:

None.

## What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
