### PR TITLE
feat: add rightSidebar config option, closes #1282

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -770,6 +770,19 @@ window.$docsify = {
 };
 ```
 
+## rightSidebar
+
+- Type : `Boolean`
+- Default: `false`
+
+Position the sidebar on the right side of the page instead of the left.
+
+```js
+window.$docsify = {
+  rightSidebar: true,
+};
+```
+
 ## routerMode
 
 Configure the URL format that the paths of your site will use.

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -53,6 +53,7 @@ const defaultDocsifyConfig = () => ({
   relativePath: false,
   repo: /** @type {string} */ (''),
   requestHeaders: /** @type {Record<string, string>} */ ({}),
+  rightSidebar: false,
   routerMode: /** @type {'hash' | 'history'} */ 'hash',
   routes: /** @type {Record<string, string | RouteHandler>} */ ({}),
   skipLink: /** @type {false | string | Record<string, string>} */ (

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -561,6 +561,9 @@ export function Render(Base) {
     initRender() {
       const config = this.config;
 
+      // Position the sidebar on the right instead of the left
+      dom.body.classList.toggle('right-sidebar', !!config.rightSidebar);
+
       // Init markdown compiler
       this.compiler = new Compiler(config, this.router);
       window.__current_docsify_compiler__ = this.compiler;

--- a/src/themes/shared/_sidebar.css
+++ b/src/themes/shared/_sidebar.css
@@ -246,6 +246,41 @@
   }
 }
 
+/* Right Sidebar */
+/* ========================================================================== */
+body.right-sidebar {
+  .sidebar {
+    left: auto;
+    right: 0;
+    translate: var(--sidebar-width);
+    border-right: 0;
+    border-left: 1px solid var(--sidebar-border-color);
+  }
+
+  .sidebar-toggle {
+    left: auto;
+    right: 0;
+  }
+
+  .sidebar-toggle-button {
+    border-radius: var(--border-radius) 0 0 var(--border-radius);
+  }
+
+  &:has(.sidebar.show) {
+    main > .content {
+      right: var(--sidebar-width);
+    }
+
+    .app-nav {
+      right: var(--sidebar-width);
+    }
+
+    .sidebar-toggle {
+      translate: calc(0px - var(--sidebar-width));
+    }
+  }
+}
+
 .sidebar-toggle-button {
   display: flex;
   flex-direction: column;

--- a/test/integration/sidebar.test.js
+++ b/test/integration/sidebar.test.js
@@ -143,3 +143,30 @@ describe('Test sidebar render toc structure', function () {
     expect(sidebarText).not.toContain('Quoted Title Without Space');
   });
 });
+
+describe('Configuration: rightSidebar', () => {
+  test('rightSidebar=true adds the right-sidebar class to <body>', async () => {
+    await docsifyInit({
+      config: {
+        rightSidebar: true,
+      },
+      markdown: {
+        homepage: '# Hello World',
+      },
+      waitForSelector: '.sidebar',
+    });
+
+    expect(document.body.classList.contains('right-sidebar')).toBe(true);
+  });
+
+  test('rightSidebar=false (default) does not add the right-sidebar class', async () => {
+    await docsifyInit({
+      markdown: {
+        homepage: '# Hello World',
+      },
+      waitForSelector: '.sidebar',
+    });
+
+    expect(document.body.classList.contains('right-sidebar')).toBe(false);
+  });
+});


### PR DESCRIPTION
### Description

Adds a `rightSidebar` boolean config option (default: `false`) that positions the sidebar on the right side of the page instead of the left.

Implemented by toggling a `right-sidebar` class on `<body>` based on the config value, with CSS handling the layout flip — desktop positioning, the mobile overlay/backdrop behavior, and the sidebar toggle button's position and slide animation.

### Related issue(s)

Closes #1282

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Added integration tests confirming the `right-sidebar` class is correctly added/omitted based on config (`test/integration/sidebar.test.js`)
- Verified full local test suite passes: `npm run build`, `npm run lint`, unit tests, integration tests, and e2e tests (Chromium, Firefox, WebKit)
- Manually tested in Chrome at desktop width and at mobile width (iPhone XR emulation), confirming:
  - Desktop: sidebar renders on the right, content shifts correctly
  - Mobile: sidebar is hidden by default, toggle button opens it as a right-side overlay with backdrop-tap-to-close, matching the existing left-sidebar mobile behavior

Screenshots below.

**Desktop, rightSidebar: true**
<img width="1920" height="2455" alt="screencapture-10-110-12-101-4000-2026-08-04-01_34_16" src="https://github.com/user-attachments/assets/93fde691-24cf-47df-9902-b4fa3ac2f5ec" />

**Mobile, sidebar closed (default)**
<img width="257" height="560" alt="Screenshot 2026-08-04 014302" src="https://github.com/user-attachments/assets/b4047b81-e713-439c-80ef-632e483c5272" />

**Mobile, sidebar open**
<img width="257" height="556" alt="Screenshot 2026-08-04 014331" src="https://github.com/user-attachments/assets/35ea5fd7-114e-41d0-8fe6-e19519b857c9" />

### Checklist

- [x] My code follows this project's style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation (`docs/configuration.md`)
- [x] This is not a breaking change