### PR TITLE
fix: preserve loose-list sidebar links when collapsed

### DIFF
--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -324,8 +324,12 @@ export function Render(Base) {
       this.#addTextAsTitleAttribute('.sidebar-nav a');
 
       if (loadSidebar && activeEl) {
-        const parent = /** @type {HTMLElement} */ (activeEl.parentElement);
-        parent.innerHTML += this.compiler.subSidebar(subMaxLevel) || '';
+        activeEl
+          .closest('li')
+          ?.insertAdjacentHTML(
+            'beforeend',
+            this.compiler.subSidebar(subMaxLevel) || '',
+          );
       } else {
         this.compiler.resetToc();
       }

--- a/src/themes/shared/_sidebar.css
+++ b/src/themes/shared/_sidebar.css
@@ -89,7 +89,7 @@
     }
 
     &.collapse {
-      > :not(a) {
+      > :not(a, p:has(> a.page-link)) {
         display: none;
       }
     }

--- a/test/e2e/sidebar.test.js
+++ b/test/e2e/sidebar.test.js
@@ -68,6 +68,50 @@ test.describe('Sidebar Tests', () => {
     await expect(activeLinkElm).toHaveText('Test >');
     expect(page.url()).toMatch(/\/test%3Efoo$/);
   });
+
+  test('keeps a loose-list page link visible when collapsed', async ({
+    page,
+  }) => {
+    await docsifyInit({
+      config: {
+        subMaxLevel: 2,
+      },
+      markdown: {
+        homepage: '# Home',
+        sidebar: `
+          - Getting started
+
+            - [Introduction](introduction.md)
+
+          - [Quick start](quickstart.md)
+        `,
+      },
+      routes: {
+        '/quickstart.md': `
+          # Quick start
+
+          ## Installation
+        `,
+      },
+      styleURLs: ['/dist/themes/core.css'],
+    });
+
+    const quickStartLink = page.locator('.sidebar-nav a[href="#/quickstart"]');
+
+    await quickStartLink.click();
+
+    const quickStartItem = page.locator(
+      '.sidebar-nav li:has(> p > a[href="#/quickstart"])',
+    );
+    const subSidebar = quickStartItem.locator(':scope > .app-sub-sidebar');
+    await expect(subSidebar).toBeVisible();
+
+    await quickStartLink.click();
+
+    await expect(quickStartItem).toHaveClass(/collapse/);
+    await expect(subSidebar).toBeHidden();
+    await expect(quickStartLink).toBeVisible();
+  });
 });
 
 test.describe('Mobile sidebar toggle', () => {


### PR DESCRIPTION
## Summary

If you click “Quick Start” and then click “Quick Start” again, it will disappear.

```markdown
- [Quick start](quickstart.md)
- [Adding pages](adding-pages.md)
- [Cover page](cover.md)

- Getting started

  - [Custom navbar](custom-navbar.md)
```

But that's normal.

```markdown
* [Quick start](quickstart.md)
* [Adding pages](adding-pages.md)
* [Cover page](cover.md)

- Getting started

  - [Custom navbar](custom-navbar.md)
```


---


## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
