### PR TITLE
docs: Adds instructions to upgrade custom plugins to v5

### DIFF
--- a/docs/v5-upgrade.md
+++ b/docs/v5-upgrade.md
@@ -110,9 +110,7 @@ View [Theme Classes](themes.md?id=classes) for more details.
 - Update version from `@4` (or non-versioned) to `@5`
 - Example: `//cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js` becomes `//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/emoji.min.js`
 
-### 5. Update the plugins you wrote
-
-The `toggleClass` function has been removed as it can be replaced effectively by the JavaScript native `Element` property `classList`. Therefore, you must make the replacement in your plugin if you used it.
+**Plugin Authors:** If you've written a custom plugin that uses `window.Docsify.dom.toggleClass`, this helper has been removed in v5. Replace it with the native `Element.classList` API.
 
 Examples:
 ```js

--- a/docs/v5-upgrade.md
+++ b/docs/v5-upgrade.md
@@ -110,6 +110,35 @@ View [Theme Classes](themes.md?id=classes) for more details.
 - Update version from `@4` (or non-versioned) to `@5`
 - Example: `//cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js` becomes `//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/emoji.min.js`
 
+### 5. Update the plugins you wrote
+
+The `toggleClass` function has been removed as it can be replaced effectively by the JavaScript native `Element` property `classList`. Therefore, you must make the replacement in your plugin if you used it.
+
+Examples:
+```js
+// v4
+window.Docsify.dom.toggleClass(element, 'className');
+
+// v5
+element.classList.toggle('className');
+```
+
+```js
+// v4
+window.Docsify.dom.toggleClass(element, 'action', 'className');
+
+// v5
+element.classList.action('className');
+```
+
+```js
+// v4
+window.Docsify.dom.toggleClass(element, isDark ? 'add' : 'remove', 'dark');
+
+// v5
+element.classList[isDark ? 'add' : 'remove']('dark');
+```
+
 ## Key Differences Summary
 
 - **CDN Path**: Changed from `/lib/` to `/dist/`

--- a/docs/v5-upgrade.md
+++ b/docs/v5-upgrade.md
@@ -115,6 +115,7 @@ View [Theme Classes](themes.md?id=classes) for more details.
 If you've written a custom plugin that uses `window.Docsify.dom.toggleClass`, this helper has been removed in v5. Replace it with the native `Element.classList` API.
 
 Examples:
+
 ```js
 // v4
 window.Docsify.dom.toggleClass(element, 'className');

--- a/docs/v5-upgrade.md
+++ b/docs/v5-upgrade.md
@@ -110,7 +110,9 @@ View [Theme Classes](themes.md?id=classes) for more details.
 - Update version from `@4` (or non-versioned) to `@5`
 - Example: `//cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js` becomes `//cdn.jsdelivr.net/npm/docsify@5/dist/plugins/emoji.min.js`
 
-**Plugin Authors:** If you've written a custom plugin that uses `window.Docsify.dom.toggleClass`, this helper has been removed in v5. Replace it with the native `Element.classList` API.
+#### Plugin Authors
+
+If you've written a custom plugin that uses `window.Docsify.dom.toggleClass`, this helper has been removed in v5. Replace it with the native `Element.classList` API.
 
 Examples:
 ```js


### PR DESCRIPTION
## Summary

Adds instructions in documentation to replace the toggleClass function in custom plugins, because this function doesn't exist anymore in v5. Instructions written in the "Upgrading" / "v4 to v5" section.
Is important because the toggleClass removal broke some plugins (like [docsify-dark-switch](https://github.com/markz-demo/docsify-dark-switch)).

## Related issue, if any:

None, because if an issue should be declared, then it must be declared in plugin's repo.

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [ ] Yes
- [x] No

## Tested in the following browsers:

- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
