### PR TITLE
feat: implement version checking for Docsify script URLs

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,9 +1,12 @@
 import { stripIndent } from 'common-tags';
+import { getDocsifyModuleUrl, getDocsifyScript } from './script.js';
 import { hyphenate, isPrimitive } from './util/core.js';
+import {
+  isDocsifyScriptUrl,
+  warnIfUnpinnedDocsifyVersion,
+} from './version-check.js';
 /** @import { Docsify } from './Docsify.js' */
 /** @import { Hooks } from './init/lifecycle.js' */
-
-const currentScript = document.currentScript;
 
 const defaultDocsifyConfig = () => ({
   alias: /** @type {Record<string, string>} */ ({}),
@@ -158,11 +161,15 @@ export default function (vm, config = {}) {
     );
   }
 
-  const script =
-    currentScript ||
-    Array.from(document.getElementsByTagName('script')).filter(n =>
-      /docsify\./.test(n.src),
-    )[0];
+  const moduleUrl = getDocsifyModuleUrl();
+  const script = getDocsifyScript();
+  const scriptUrl = moduleUrl
+    ? isDocsifyScriptUrl(moduleUrl)
+      ? moduleUrl
+      : undefined
+    : script?.src;
+
+  warnIfUnpinnedDocsifyVersion(scriptUrl);
 
   if (script) {
     for (const prop of /** @type {(keyof DocsifyConfig)[]} */ (

--- a/src/core/module.js
+++ b/src/core/module.js
@@ -1,1 +1,5 @@
+import { setDocsifyModuleUrl } from './script.js';
+
+setDocsifyModuleUrl(import.meta.url);
+
 export * from './Docsify.js';

--- a/src/core/script.js
+++ b/src/core/script.js
@@ -1,0 +1,24 @@
+const currentScript = /** @type {HTMLScriptElement | null} */ (
+  document.currentScript
+);
+
+/** @type {string | undefined} */
+let moduleUrl;
+
+export function getDocsifyScript() {
+  return (
+    currentScript ||
+    Array.from(document.getElementsByTagName('script')).find(script =>
+      /docsify\./.test(script.src),
+    )
+  );
+}
+
+export function getDocsifyModuleUrl() {
+  return moduleUrl;
+}
+
+/** @param {string} url */
+export function setDocsifyModuleUrl(url) {
+  moduleUrl = url;
+}

--- a/src/core/version-check.js
+++ b/src/core/version-check.js
@@ -1,0 +1,101 @@
+const VERSION = String.raw`v?(?:0|[1-9]\d?)(?:\.(?:0|[1-9]\d*)){0,2}(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?`;
+const VERSION_VALUE = new RegExp(`^${VERSION}$`);
+const VERSION_PATHS = [
+  new RegExp(`(?:^|/)docsify@${VERSION}(?:/|$)`, 'i'),
+  new RegExp(`(?:^|/)docsify/${VERSION}(?:/|$)`, 'i'),
+  new RegExp(
+    `(?:^|/)docsify(?:\\.module)?[-.]${VERSION}(?:\\.min)?\\.js$`,
+    'i',
+  ),
+  new RegExp(
+    `(?:^|/)docsify[-.]${VERSION}(?:\\.module)?(?:\\.min)?\\.js$`,
+    'i',
+  ),
+];
+
+let hasWarned = false;
+
+/** @param {string} value */
+function parseUrl(value) {
+  try {
+    return new URL(value, 'https://docsify.js.org');
+  } catch {
+    return null;
+  }
+}
+
+/** @param {string} pathname */
+function decodePathname(pathname) {
+  try {
+    return decodeURIComponent(pathname);
+  } catch {
+    return pathname;
+  }
+}
+
+/** @param {string} scriptUrl */
+export function hasPinnedDocsifyVersion(scriptUrl) {
+  const url = parseUrl(scriptUrl);
+
+  if (!url) {
+    return false;
+  }
+
+  if (
+    ['v', 'version'].some(param =>
+      url.searchParams.getAll(param).some(value => VERSION_VALUE.test(value)),
+    )
+  ) {
+    return true;
+  }
+
+  const pathname = decodePathname(url.pathname);
+
+  return VERSION_PATHS.some(pattern => pattern.test(pathname));
+}
+
+/** @param {string} scriptUrl */
+export function isDocsifyScriptUrl(scriptUrl) {
+  const url = parseUrl(scriptUrl);
+
+  if (!url) {
+    return false;
+  }
+
+  const pathname = decodePathname(url.pathname);
+  const filename = pathname.split('/').pop() || '';
+
+  if (/^docsify(?:[.@_-].*)?\.js$/i.test(filename)) {
+    return true;
+  }
+
+  switch (url.hostname) {
+    case 'cdn.jsdelivr.net':
+      return /^\/(?:npm\/docsify|gh\/docsifyjs\/docsify)(?:@|\/)/i.test(
+        pathname,
+      );
+    case 'unpkg.com':
+      return /^\/docsify(?:@|\/)/i.test(pathname);
+    case 'cdn.bootcdn.net':
+    case 'cdnjs.cloudflare.com':
+      return /^\/ajax\/libs\/docsify\//i.test(pathname);
+    default:
+      return false;
+  }
+}
+
+/** @param {string | undefined} scriptUrl */
+export function warnIfUnpinnedDocsifyVersion(scriptUrl) {
+  if (!scriptUrl || hasWarned || hasPinnedDocsifyVersion(scriptUrl)) {
+    return;
+  }
+
+  hasWarned = true;
+
+  // eslint-disable-next-line no-console
+  console.error(
+    `[Docsify] Unpinned version detected in the Docsify script URL: ${scriptUrl}\n` +
+      'This site WILL BREAK when that URL begins serving a future major version and may break unexpectedly on minor or patch updates. ' +
+      'Pin Docsify to a version in the URL (for example, docsify@5.0.0).',
+  );
+}

--- a/test/e2e/example.test.js
+++ b/test/e2e/example.test.js
@@ -2,6 +2,28 @@ import docsifyInit from '../helpers/docsify-init.js';
 import { test, expect } from './fixtures/docsify-init-fixture.js';
 
 test.describe('Creating a Docsify site (e2e tests in Playwright)', () => {
+  test('warns once when the Docsify script URL is not versioned', async ({
+    page,
+  }) => {
+    const errors = [];
+
+    page.on('console', message => {
+      if (
+        message.type() === 'error' &&
+        message.text().includes('[Docsify] Unpinned version')
+      ) {
+        errors.push(message.text());
+      }
+    });
+
+    await page.setContent('<div id="app"></div>');
+    await page.addScriptTag({ url: '/dist/docsify.js' });
+    await page.locator('#main').waitFor();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('This site WILL BREAK');
+  });
+
   test('manual docsify site using playwright methods', async ({ page }) => {
     // Add docsify target element
     await page.setContent('<div id="app"></div>');
@@ -18,7 +40,7 @@ test.describe('Creating a Docsify site (e2e tests in Playwright)', () => {
     await page.addStyleTag({ url: '/dist/themes/core.css' });
 
     // Inject docsify.js
-    await page.addScriptTag({ url: '/dist/docsify.js' });
+    await page.addScriptTag({ url: '/dist/docsify.js?v=5.0.0' });
 
     // Wait for docsify to initialize
     await page.locator('#main').waitFor();

--- a/test/helpers/docsify-init.js
+++ b/test/helpers/docsify-init.js
@@ -8,7 +8,7 @@ import { waitForSelector } from './wait-for.js';
 
 const mock = _mock.default;
 const docsifyPATH = '../../dist/docsify.js'; // JSDOM
-const docsifyURL = '/dist/docsify.js'; // Playwright
+const docsifyURL = '/dist/docsify.js?v=5.0.0'; // Playwright
 
 /**
  * Jest / Playwright helper for creating custom docsify test sites

--- a/test/unit/version-check.test.js
+++ b/test/unit/version-check.test.js
@@ -1,0 +1,94 @@
+import { jest } from '@jest/globals';
+import {
+  hasPinnedDocsifyVersion,
+  isDocsifyScriptUrl,
+  warnIfUnpinnedDocsifyVersion,
+} from '../../src/core/version-check.js';
+
+describe('Docsify script version check', () => {
+  test.each([
+    'https://cdn.jsdelivr.net/npm/docsify@5.0.0/dist/docsify.js',
+    'https://unpkg.com/docsify@5.0.0/dist/docsify.js',
+    'https://cdn.bootcdn.net/ajax/libs/docsify/5.0.0/docsify.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/docsify/5.0.0/docsify.js',
+    'https://cdn.jsdelivr.net/npm/docsify@5/dist/docsify.module.js',
+    'https://unpkg.com/docsify@5.0/dist/docsify.module.min.js',
+    'https://unpkg.com/docsify@5.0.0-rc.1/dist/docsify.module.js',
+    '/assets/docsify-5.0.0.js',
+    '/assets/docsify.5.0.0.min.js',
+    '/assets/docsify-5.0.0.module.min.js',
+    '/docsify/5.0.0/docsify.js',
+    '/assets/docsify.js?v=5',
+    '/assets/docsify.js?version=5.0.0',
+  ])('recognizes a pinned version in %s', scriptUrl => {
+    expect(hasPinnedDocsifyVersion(scriptUrl)).toBe(true);
+  });
+
+  test.each([
+    'https://cdn.jsdelivr.net/npm/docsify/dist/docsify.js',
+    'https://unpkg.com/docsify@latest/dist/docsify.js',
+    'https://cdn.bootcdn.net/ajax/libs/docsify/latest/docsify.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/docsify/2026/docsify.js',
+    '/assets/docsify.js',
+    '/2026/assets/docsify.js',
+    '/assets/docsify-a1b2c3.js',
+    '/assets/docsify.js?cache=5.0.0',
+    '/assets/docsify.js?v=20260903',
+    '/assets/docsify.js#version=5.0.0',
+    'not a valid URL%',
+  ])(
+    'does not mistake an unpinned URL for a pinned version in %s',
+    scriptUrl => {
+      expect(hasPinnedDocsifyVersion(scriptUrl)).toBe(false);
+    },
+  );
+
+  test.each([
+    'https://cdn.jsdelivr.net/npm/docsify/dist/docsify.module.js',
+    'https://unpkg.com/docsify/dist/module.js',
+    'https://cdn.bootcdn.net/ajax/libs/docsify/5.0.0/module.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/docsify/5.0.0/module.js',
+    '/assets/docsify.module.js',
+  ])('recognizes a Docsify ESM distribution URL in %s', scriptUrl => {
+    expect(isDocsifyScriptUrl(scriptUrl)).toBe(true);
+  });
+
+  test.each([
+    '/assets/app.js',
+    '/assets/vendor.js?v=5.0.0',
+    'file:///project/docsify/src/core/module.js',
+  ])('ignores a non-Docsify application bundle URL in %s', scriptUrl => {
+    expect(isDocsifyScriptUrl(scriptUrl)).toBe(false);
+  });
+
+  test('does not warn without a URL or for a pinned URL', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    warnIfUnpinnedDocsifyVersion();
+    warnIfUnpinnedDocsifyVersion(
+      'https://cdn.jsdelivr.net/npm/docsify@5.0.0/dist/docsify.js',
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('emits one forceful error for an unpinned URL', () => {
+    const scriptUrl = 'https://cdn.jsdelivr.net/npm/docsify/dist/docsify.js';
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    warnIfUnpinnedDocsifyVersion(scriptUrl);
+    warnIfUnpinnedDocsifyVersion(scriptUrl);
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('This site WILL BREAK'),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(scriptUrl),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Warn users when Docsify is loaded from a URL that does not include a pinned version.

Unversioned CDN URLs may begin serving a future major release automatically, which can break existing documentation sites. Minor or patch releases may also introduce unexpected regressions.

When an unpinned Docsify URL is detected, Docsify now emits a single, prominent `console.error` containing the detected URL and guidance to pin a version.

## Supported URL formats

The version check recognizes:

- Package versions:
  - `docsify@5`
  - `docsify@5.0`
  - `docsify@5.0.0`
  - `docsify@5.0.0-rc.1`
- Versioned paths:
  - `/docsify/5.0.0/docsify.js`
- Versioned filenames:
  - `/docsify-5.0.0.js`
- Version query parameters:
  - `?v=5.0.0`
  - `?version=5.0.0`

Known URL formats are supported for:

- jsDelivr
- unpkg
- BootCDN
- cdnjs

Self-hosted Docsify scripts are checked as well.

## IIFE and ESM support

- Classic IIFE builds use `document.currentScript`, with the existing `<script>` lookup as a fallback.
- ESM builds use `import.meta.url`.
- The ESM implementation is compatible with the build configuration introduced in #2751.
- Ordinary npm/application bundles are ignored when their output URL cannot be identified as a Docsify distribution, avoiding false-positive warnings.

## Example warning

```text
[Docsify] Unpinned version detected in the Docsify script URL: https://cdn.jsdelivr.net/npm/docsify/dist/docsify.js
This site WILL BREAK when that URL begins serving a future major version and may break unexpectedly on minor or patch updates. Pin Docsify to a version in the URL (for example, docsify@5.0.0).
```

The warning does not prevent Docsify from starting and is emitted at most once.

## Testing

- Added unit coverage for:
  - jsDelivr, unpkg, BootCDN, and cdnjs
  - Major-only, minor, patch, and prerelease versions
  - Path, filename, and query-parameter versions
  - Unversioned URLs and `@latest`
  - Dates, cache values, hashes, and unrelated numbers
  - ESM distribution detection
  - npm/application bundle detection
  - Single-warning behavior
- Added an E2E test using a real unversioned Docsify script.
- Updated existing test URLs to use an explicitly pinned version.

Validation completed:

- Unit tests: 73 passed
- Integration tests: 74 passed
- Chromium E2E tests: 83 passed
- Firefox targeted E2E tests: 4 passed
- IIFE and simulated ESM builds passed
- ESLint, Prettier, and TypeScript checks passed

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## What kind of change does this PR introduce?

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- If yes, describe the impact and migration path for existing applications. -->

- [x] Yes
- [x] No

## Tested in the following browsers:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
